### PR TITLE
Update root route to return JSON metadata

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -30,13 +30,17 @@ from service.common import status  # HTTP Status Codes
 ######################################################################
 # GET INDEX
 ######################################################################
-@app.route("/")
+@app.route("/", methods=["GET"])
 def index():
     """Root URL response"""
-    return (
-        "Reminder: return some useful information in json format about the service here",
-        status.HTTP_200_OK,
-    )
+    return {
+        "name": "Product Catalog Service",
+        "version": "1.0",
+        "paths": [
+            "/products",
+            "/products/{id}"
+        ]
+    }, status.HTTP_200_OK
 
 
 ######################################################################

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -76,8 +76,16 @@ class TestProductService(TestCase):
 
     def test_index(self):
         """It should call the home page"""
-        resp = self.client.get("/")
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.content_type, "application/json")
+        data = response.get_json()
+        self.assertIn("name", data)
+        self.assertIn("version", data)
+        self.assertIn("paths", data)
+        self.assertEqual(data["name"], "Product Catalog Service")
+        self.assertEqual(data["version"], "1.0")
+        self.assertIsInstance(data["paths"], list)
 
     def test_404_not_found(self):
         """It should return 404 for an unknown route"""


### PR DESCRIPTION
Updated the root endpoint (GET /) to return JSON metadata instead of plain text or HTML.

Response now includes:
- service name
- version
- list of available API paths

Example response:
{
  "name": "Product Catalog Service",
  "version": "1.0",
  "paths": [
    "/products",
    "/products/{id}"
  ]
}

Validation:
- GET / returns HTTP 200
- Content-Type is application/json
- Response contains keys: name, version, paths

All tests pass.

Closes #8