### PR TITLE
Add GitHub Actions CI workflow and badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pipenv
+          pipenv install --system --dev
+
+      - name: Lint with flake8
+        run: |
+          flake8 service tests --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 service tests --count --max-complexity=10 --max-line-length=127 --statistics
+
+      - name: Lint with pylint
+        run: |
+          pylint service tests --max-line-length=127
+
+      - name: Run tests with pytest
+        run: |
+          pytest --pspec --cov=service --cov-fail-under=95 --disable-warnings
+        env:
+          DATABASE_URI: "postgresql+psycopg://postgres:postgres@localhost:5432/testdb"
+          RETRY_COUNT: "1"
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |
@@ -53,7 +53,7 @@ jobs:
 
       - name: Run tests with pytest
         run: |
-          pytest --pspec --cov=service --cov-fail-under=95 --disable-warnings
+          pytest --pspec --cov=service --cov-fail-under=95 --cov-report=xml:coverage.xml --disable-warnings
         env:
           DATABASE_URI: "postgresql+psycopg://postgres:postgres@localhost:5432/testdb"
           RETRY_COUNT: "1"
@@ -62,3 +62,4 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NYU DevOps Project Template
 
+[![CI](https://github.com/CSCI-GA-2820-SP26-001/products/actions/workflows/ci.yml/badge.svg)](https://github.com/CSCI-GA-2820-SP26-001/products/actions)
+[![codecov](https://codecov.io/gh/CSCI-GA-2820-SP26-001/products/graph/badge.svg?token=S1RMJ071KF)](https://codecov.io/gh/CSCI-GA-2820-SP26-001/products)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python](https://img.shields.io/badge/Language-Python-blue.svg)](https://python.org/)
 


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` to run CI on every push to master and pull request
- Workflow runs flake8, pylint, pytest (with 95% coverage threshold), and uploads coverage to Codecov
- Add CI and Codecov badges to README.md

## Details
- Uses PostgreSQL 16 service container for tests
- Installs dependencies via Pipenv
- Runs flake8 for syntax and style checks
- Runs pylint for code quality
- Runs pytest with `--cov-fail-under=95`
- Uploads coverage report to Codecov using `CODECOV_TOKEN` secret

## Acceptance Criteria
- [x] CI triggers on PRs and pushes to master
- [x] Tests, linting, and coverage run automatically
- [x] Coverage uploaded to Codecov
- [x] Badges added to README

Closes #24