### PR TITLE
Add CI and Codecov badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # NYU DevOps Project Template
 
+<!-- CI and Codecov badges added for visibility -->
+
+[![CI](https://github.com/CSCI-GA-2820-SP26-001/products/actions/workflows/ci.yml/badge.svg)](https://github.com/CSCI-GA-2820-SP26-001/products/actions)
+
+[![codecov](https://codecov.io/gh/CSCI-GA-2820-SP26-001/products/branch/master/graph/badge.svg)](https://codecov.io/gh/CSCI-GA-2820-SP26-001/products)
+
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python](https://img.shields.io/badge/Language-Python-blue.svg)](https://python.org/)
 


### PR DESCRIPTION
Adds CI and Codecov badges to README and verifies CI/coverage setup.

Closes #25