### PR TITLE
Create PostgreSQL StatefulSet Manifests #27

### DIFF
--- a/k8s/postgres/postgres-pvc.yaml
+++ b/k8s/postgres/postgres-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/k8s/postgres/postgres-secret.yaml
+++ b/k8s/postgres/postgres-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-secret
+type: Opaque
+stringData:
+  POSTGRES_DB: products
+  POSTGRES_USER: postgres
+  POSTGRES_PASSWORD: postgres

--- a/k8s/postgres/postgres-service.yaml
+++ b/k8s/postgres/postgres-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/k8s/postgres/postgres-statefulset.yaml
+++ b/k8s/postgres/postgres-statefulset.yaml
@@ -36,6 +36,16 @@ spec:
                   key: POSTGRES_PASSWORD
             - name: PGDATA
               value: /var/lib/postgresql/data/pgdata
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "postgres"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "postgres"]
+            initialDelaySeconds: 30
+            periodSeconds: 20
           volumeMounts:
             - name: postgres-storage
               mountPath: /var/lib/postgresql/data

--- a/k8s/postgres/postgres-statefulset.yaml
+++ b/k8s/postgres/postgres-statefulset.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_DB
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_PASSWORD
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: postgres-storage
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: postgres-storage
+          persistentVolumeClaim:
+            claimName: postgres-pvc

--- a/service/routes.py
+++ b/service/routes.py
@@ -215,3 +215,9 @@ def delete_product(product_id):
     product.delete()
     app.logger.info("Product [%s] deleted", product_id)
     return "", status.HTTP_204_NO_CONTENT
+
+
+@app.route("/health", methods=["GET"])
+def health_check():
+    """Health check endpoint"""
+    return {"status": "OK"}, 200

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -779,3 +779,10 @@ class TestProductService(TestCase):
         """It should return 404 when purchasing a missing product"""
         resp = self.client.put("/products/999999/purchase")
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_health_endpoint(self):
+        """It should return 200 OK for health check"""
+        response = self.client.get("/health")
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        self.assertEqual(data["status"], "OK")


### PR DESCRIPTION
## What this PR does
- Adds PostgreSQL manifests under `k8s/postgres/`
- Includes Secret, Service, PVC, and StatefulSet
- Configures database name `products`
- Adds `/health` endpoint for Kubernetes health checks

## Testing
- Ran `make cluster`
- Ran `kubectl apply -f k8s/postgres/`
- Verified StatefulSet, PVC, and Service created
- Verified postgres pod running
- Verified database "products" exists
- Ran `make lint` and `make test` (all passed, coverage >95%)

## Related Issue
Closes #27