### PR TITLE
Feature/UI product delete 44

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ make run
 
 The service will be available at `http://localhost:8080`.
 
-Admin UI page:
+Admin UI pages:
 
-- `http://localhost:8080/admin/products/update`
-- Allows store managers to retrieve a product by id, edit fields, and submit updates.
+- `http://localhost:8080/admin/products/update` — Retrieve a product by id, edit fields, and submit updates.
+- `http://localhost:8080/admin/products/delete` — Delete a product by id.
 
 ## Running Tests
 
@@ -133,6 +133,15 @@ Returns a product by its ID.
 Updates an existing product. Requires `Content-Type: application/json`. The request body uses the same fields as Create.
 
 **Response:** `200 OK` with the updated product, or `404 Not Found` if it does not exist.
+
+### Admin Product Delete UI
+
+`GET /admin/products/delete`
+
+Renders a lightweight admin page that supports:
+- entering a product id
+- deleting the product and viewing a success message
+- displaying an error if the product does not exist
 
 ### Admin Product Update UI
 

--- a/features/delete_product_ui.feature
+++ b/features/delete_product_ui.feature
@@ -1,0 +1,20 @@
+Feature: Delete product from admin UI
+  As an eCommerce manager
+  I need to delete a product from the admin UI
+  So that I can remove products that should no longer appear in the catalog
+
+  Background:
+    Given a product with id "1" exists in the database
+
+  Scenario: Delete an existing product from the admin interface
+    Given I am on the "Delete Product" admin page
+    When I enter "1" in the ID field
+    And I press the "Delete" button
+    Then the product should be deleted successfully
+    And I should see a success message indicating the product was removed
+
+  Scenario: Show an error for a missing product
+    Given I am on the "Delete Product" admin page
+    When I enter "999999" in the ID field
+    And I press the "Delete" button
+    Then I should see an error message indicating the product was not found

--- a/service/routes.py
+++ b/service/routes.py
@@ -49,6 +49,12 @@ def admin_update_product_page():
     return render_template("admin_product_update.html"), status.HTTP_200_OK
 
 
+@app.route("/admin/products/delete", methods=["GET"])
+def admin_delete_product_page():
+    """Render the admin UI for deleting products."""
+    return render_template("admin_product_delete.html"), status.HTTP_200_OK
+
+
 ######################################################################
 #  R E S T   A P I   E N D P O I N T S
 ######################################################################

--- a/service/static/admin_product_delete.css
+++ b/service/static/admin_product_delete.css
@@ -1,0 +1,85 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #f6f8fb;
+  color: #1f2937;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.container {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 2rem 1rem 3rem;
+}
+
+.page-header h1 {
+  margin: 0 0 0.5rem;
+}
+
+.page-header p {
+  margin: 0 0 1.5rem;
+  color: #4b5563;
+}
+
+.card {
+  background: #ffffff;
+  border: 1px solid #dbe3ec;
+  border-radius: 10px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.card h2 {
+  margin: 0 0 0.8rem;
+  font-size: 1rem;
+}
+
+.inline-form {
+  display: grid;
+  grid-template-columns: 100px 1fr auto;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+input,
+button {
+  font: inherit;
+}
+
+input {
+  width: 100%;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 0.55rem 0.65rem;
+}
+
+input:focus {
+  border-color: #2563eb;
+  outline: 2px solid rgba(37, 99, 235, 0.15);
+}
+
+button {
+  border: 1px solid #b91c1c;
+  background: #dc2626;
+  color: #ffffff;
+  border-radius: 8px;
+  padding: 0.55rem 0.9rem;
+  cursor: pointer;
+}
+
+.message {
+  min-height: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 0.8rem;
+}
+
+.message.success {
+  color: #166534;
+}
+
+.message.error {
+  color: #b91c1c;
+}

--- a/service/static/admin_product_delete.js
+++ b/service/static/admin_product_delete.js
@@ -1,0 +1,64 @@
+(function initAdminDeletePage() {
+  "use strict";
+
+  var deleteInput = document.getElementById("delete-product-id");
+  var deleteButton = document.getElementById("delete-button");
+  var message = document.getElementById("message");
+
+  function showMessage(text, type) {
+    message.textContent = text;
+    message.className = "message";
+    if (type) {
+      message.classList.add(type);
+    }
+  }
+
+  async function deleteProduct() {
+    var productId = parseInt(deleteInput.value, 10);
+    if (!Number.isInteger(productId) || productId <= 0) {
+      showMessage("Enter a valid product ID before deleting.", "error");
+      return;
+    }
+
+    // First verify the product exists
+    var getResponse = await fetch("/products/" + productId, { method: "GET" });
+    if (!getResponse.ok) {
+      var payload = await getResponse.json().catch(function () {
+        return null;
+      });
+      var errorMsg =
+        payload && payload.message
+          ? payload.message
+          : "Product with id " + productId + " was not found.";
+      showMessage(errorMsg, "error");
+      return;
+    }
+
+    showMessage("Deleting product...", null);
+
+    var response = await fetch("/products/" + productId, { method: "DELETE" });
+
+    if (response.status === 204) {
+      deleteInput.value = "";
+      showMessage(
+        "Product " + productId + " has been deleted successfully.",
+        "success"
+      );
+      return;
+    }
+
+    var data = await response.json().catch(function () {
+      return null;
+    });
+    showMessage(
+      data && data.message ? data.message : "Failed to delete product.",
+      "error"
+    );
+  }
+
+  deleteButton.addEventListener("click", function onDeleteClick() {
+    deleteProduct().catch(function onDeleteError() {
+      showMessage("Unexpected error while deleting the product.", "error");
+    });
+  });
+})();

--- a/service/templates/admin_product_delete.html
+++ b/service/templates/admin_product_delete.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Admin Product Delete</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='admin_product_delete.css') }}" />
+  </head>
+  <body>
+    <main class="container">
+      <header class="page-header">
+        <h1>Delete Product</h1>
+        <p>Enter a product ID and press Delete to remove it from the catalog.</p>
+      </header>
+
+      <section class="card">
+        <h2>Delete Product</h2>
+        <div class="inline-form">
+          <label for="delete-product-id">Product ID</label>
+          <input id="delete-product-id" type="number" min="1" placeholder="e.g. 1" />
+          <button id="delete-button" type="button">Delete</button>
+        </div>
+      </section>
+
+      <section id="message" class="message" aria-live="polite"></section>
+    </main>
+
+    <script src="{{ url_for('static', filename='admin_product_delete.js') }}"></script>
+  </body>
+</html>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -93,6 +93,14 @@ class TestProductService(TestCase):
         self.assertIn("Update Product", page)
         self.assertIn("Retrieve Product", page)
 
+    def test_admin_delete_product_page(self):
+        """It should render the admin delete product UI page"""
+        response = self.client.get("/admin/products/delete")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("text/html", response.content_type)
+        page = response.get_data(as_text=True)
+        self.assertIn("Delete Product", page)
+
     def test_404_not_found(self):
         """It should return 404 JSON for an unknown route"""
         resp = self.client.get("/nonexistent-route")


### PR DESCRIPTION
## Summary

- Added a simple, clean admin UI page to delete products at `GET /admin/products/delete`.
- UI verifies the product exists before attempting deletion, showing an error if not found.
- On successful deletion, clears the input and displays a success message.
- Added BDD coverage in `features/delete_product_ui.feature` for delete success and product-not-found behavior.
- Updated README with admin UI usage and endpoint documentation.

## Changes

- **Backend route**
  - Added admin page route in `service/routes.py`:
    - `GET /admin/products/delete` renders `admin_product_delete.html`

- **UI files**
  - Added `service/templates/admin_product_delete.html`
  - Added `service/static/admin_product_delete.css`
  - Added `service/static/admin_product_delete.js`
  - UI supports:
    - Enter product ID
    - Delete via `DELETE /products/{id}`
    - Pre-check existence via `GET /products/{id}` before deleting
    - Show success and error messages
    - Clear input on successful deletion

- **Tests**
  - Added route test in `tests/test_routes.py`:
    - `test_admin_delete_product_page`

- **BDD**
  - Added `features/delete_product_ui.feature` with:
    - Delete success scenario
    - Product-not-found scenario

- **Docs**
  - Updated `README.md` to include admin delete UI endpoint and usage details.

## Tests

### Automated

- All 45 tests pass
- `service/routes.py` at 100% coverage
- Lint passes

Closes #44