### PR TITLE
Add admin UI page for reading products by id

### DIFF
--- a/features/read_product_ui.feature
+++ b/features/read_product_ui.feature
@@ -1,0 +1,17 @@
+Feature: Read product from admin UI
+  As an eCommerce manager
+  I need the ability to retrieve a product by its ID on the admin UI
+  So that I can quickly look up a specific product's details
+
+  Background:
+    Given a product with id "1" exists in the database
+
+  Scenario: Retrieve an existing product from the admin interface
+    Given I am on the "Read Product" admin page
+    When I enter "1" in the ID field and press the "Retrieve" button
+    Then the product details should be displayed in the form fields
+
+  Scenario: Show an error for a missing product
+    Given I am on the "Read Product" admin page
+    When I enter "999999" in the ID field and press the "Retrieve" button
+    Then I should see an error message indicating the product was not found

--- a/service/routes.py
+++ b/service/routes.py
@@ -61,6 +61,12 @@ def admin_delete_product_page():
     return render_template("admin_product_delete.html"), status.HTTP_200_OK
 
 
+@app.route("/admin/products/read", methods=["GET"])
+def admin_read_product_page():
+    """Render the admin UI for retrieving products by id."""
+    return render_template("admin_product_read.html"), status.HTTP_200_OK
+
+
 ######################################################################
 #  R E S T   A P I   E N D P O I N T S
 ######################################################################

--- a/service/static/admin_product_read.css
+++ b/service/static/admin_product_read.css
@@ -1,0 +1,106 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #f6f8fb;
+  color: #1f2937;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.container {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 2rem 1rem 3rem;
+}
+
+.page-header h1 {
+  margin: 0 0 0.5rem;
+}
+
+.page-header p {
+  margin: 0 0 1.5rem;
+  color: #4b5563;
+}
+
+.card {
+  background: #ffffff;
+  border: 1px solid #dbe3ec;
+  border-radius: 10px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.card h2 {
+  margin: 0 0 0.8rem;
+  font-size: 1rem;
+}
+
+.inline-form {
+  display: grid;
+  grid-template-columns: 100px 1fr auto;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.field-grid {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 0.6rem 0.8rem;
+  align-items: center;
+}
+
+input,
+textarea,
+button {
+  font: inherit;
+}
+
+input,
+textarea {
+  width: 100%;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 0.55rem 0.65rem;
+}
+
+input:focus,
+textarea:focus {
+  border-color: #2563eb;
+  outline: 2px solid rgba(37, 99, 235, 0.15);
+}
+
+input[readonly],
+textarea[readonly],
+input:disabled {
+  background: #f8fafc;
+}
+
+input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+}
+
+button {
+  border: 1px solid #1d4ed8;
+  background: #2563eb;
+  color: #ffffff;
+  border-radius: 8px;
+  padding: 0.55rem 0.9rem;
+  cursor: pointer;
+}
+
+.message {
+  min-height: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 0.8rem;
+}
+
+.message.success {
+  color: #166534;
+}
+
+.message.error {
+  color: #b91c1c;
+}

--- a/service/static/admin_product_read.js
+++ b/service/static/admin_product_read.js
@@ -1,0 +1,80 @@
+(function initAdminReadPage() {
+  "use strict";
+
+  const retrieveInput = document.getElementById("retrieve-product-id");
+  const retrieveButton = document.getElementById("retrieve-button");
+  const message = document.getElementById("message");
+
+  const nameInput = document.getElementById("name");
+  const descriptionInput = document.getElementById("description");
+  const priceInput = document.getElementById("price");
+  const categoryInput = document.getElementById("category");
+  const stockInput = document.getElementById("stock");
+  const availableInput = document.getElementById("available");
+
+  function showMessage(text, type) {
+    message.textContent = text;
+    message.className = "message";
+    if (type) {
+      message.classList.add(type);
+    }
+  }
+
+  function clearForm() {
+    nameInput.value = "";
+    descriptionInput.value = "";
+    priceInput.value = "";
+    categoryInput.value = "";
+    stockInput.value = "";
+    availableInput.checked = false;
+  }
+
+  function fillForm(product) {
+    nameInput.value = product.name || "";
+    descriptionInput.value = product.description || "";
+    priceInput.value = product.price || "";
+    categoryInput.value = product.category || "";
+    stockInput.value = String(product.stock ?? "");
+    availableInput.checked = Boolean(product.available);
+  }
+
+  function getErrorMessage(payload, fallback) {
+    if (payload && payload.message) {
+      return payload.message;
+    }
+    return fallback;
+  }
+
+  async function retrieveProduct() {
+    const productId = parseInt(retrieveInput.value, 10);
+    if (!Number.isInteger(productId) || productId <= 0) {
+      clearForm();
+      showMessage("Enter a valid product ID before retrieving.", "error");
+      return;
+    }
+
+    clearForm();
+    showMessage("Retrieving product...", null);
+
+    const response = await fetch(`/products/${productId}`, { method: "GET" });
+    const payload = await response.json().catch(() => null);
+
+    if (!response.ok) {
+      showMessage(
+        getErrorMessage(payload, "Could not retrieve this product."),
+        "error"
+      );
+      return;
+    }
+
+    fillForm(payload);
+    showMessage(`Product ${payload.id} retrieved successfully.`, "success");
+  }
+
+  retrieveButton.addEventListener("click", function onRetrieveClick() {
+    retrieveProduct().catch(function onRetrieveError() {
+      clearForm();
+      showMessage("Unexpected error while retrieving the product.", "error");
+    });
+  });
+})();

--- a/service/templates/admin_product_read.html
+++ b/service/templates/admin_product_read.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Admin Product Read</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='admin_product_read.css') }}" />
+  </head>
+  <body>
+    <main class="container">
+      <header class="page-header">
+        <h1>Read Product</h1>
+        <p>Retrieve a specific product by id to view its details.</p>
+      </header>
+
+      <section class="card">
+        <h2>Retrieve Product</h2>
+        <div class="inline-form">
+          <label for="retrieve-product-id">Product ID</label>
+          <input id="retrieve-product-id" type="number" min="1" placeholder="e.g. 1" />
+          <button id="retrieve-button" type="button">Retrieve</button>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2>Product Details</h2>
+        <form id="read-form">
+          <div class="field-grid">
+            <label for="name">Name</label>
+            <input id="name" name="name" readonly />
+
+            <label for="description">Description</label>
+            <textarea id="description" name="description" rows="3" readonly></textarea>
+
+            <label for="price">Price</label>
+            <input id="price" name="price" readonly />
+
+            <label for="category">Category</label>
+            <input id="category" name="category" readonly />
+
+            <label for="stock">Stock Quantity</label>
+            <input id="stock" name="stock" type="number" readonly />
+
+            <label for="available">Availability</label>
+            <input id="available" name="available" type="checkbox" disabled />
+          </div>
+        </form>
+      </section>
+
+      <section id="message" class="message" aria-live="polite"></section>
+    </main>
+
+    <script src="{{ url_for('static', filename='admin_product_read.js') }}"></script>
+  </body>
+</html>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -110,6 +110,15 @@ class TestProductService(TestCase):
         page = response.get_data(as_text=True)
         self.assertIn("Delete Product", page)
 
+    def test_admin_read_product_page(self):
+        """It should render the admin read product UI page"""
+        response = self.client.get("/admin/products/read")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("text/html", response.content_type)
+        page = response.get_data(as_text=True)
+        self.assertIn("Read Product", page)
+        self.assertIn("Retrieve Product", page)
+
     def test_404_not_found(self):
         """It should return 404 JSON for an unknown route"""
         resp = self.client.get("/nonexistent-route")


### PR DESCRIPTION
## Summary
- Added a clean admin UI page to retrieve a single product by ID at `GET /admin/products/read`.
- Implemented retrieve-by-ID flow in the UI with read-only form population and success/error messaging.
- Added BDD coverage in `features/read_product_ui.feature` for successful retrieval and missing-product behavior.

## Changes

### Backend route
- Added admin page route in `service/routes.py`:
  - `GET /admin/products/read` renders `admin_product_read.html`

### UI files
- Added `service/templates/admin_product_read.html`
- Added `service/static/admin_product_read.css`
- Added `service/static/admin_product_read.js`

UI supports:
- Enter product ID and retrieve one product
- Populate read-only fields: `name`, `description`, `price`, `category`, `stock`, `available`
- Show success/error/loading messages
- Clear stale form state on invalid/failed retrieve


### Tests
- Added route test in `tests/test_routes.py`:
  - `test_admin_read_product_page`

### BDD
- Added `features/read_product_ui.feature` with:
  - Retrieve existing product scenario
  - Product-not-found scenario

## Tests
- make test passes with required coverage
- make lint passes
- Started service and opened:
  - `http://localhost:8080/admin/products/read`
- Verified:
  - Happy-path retrieve by existing ID populates all read-only fields
  - Missing ID (`999999`) shows not-found error message
  - Invalid/empty ID shows validation message
