### PR TITLE
Add Kubernetes manifests, Dockerfile, and Makefile image rename for products service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.github
+.vscode
+.devcontainer
+.pytest_cache
+.coverage
+__pycache__
+*.pyc
+tests
+features
+k8s
+htmlcov
+coverage.xml
+.env
+*.md
+Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir --upgrade pip pipenv
+
+COPY Pipfile Pipfile.lock ./
+RUN pipenv sync --system
+
+COPY wsgi.py ./
+COPY service/ ./service/
+
+RUN useradd --uid 1000 --create-home appuser && chown -R appuser /app
+USER appuser
+
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["gunicorn", "--bind", "0.0.0.0:8080", "--log-level=info", "wsgi:app"]

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ REGISTRY ?= cluster-registry:5000
 IMAGE_NAME ?= petshop
 IMAGE_TAG ?= 1.0
 IMAGE ?= $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
+POSTGRES_IMAGE ?= postgres:15
 PLATFORM ?= "linux/amd64,linux/arm64"
 CLUSTER ?= nyu-devops
 
@@ -62,6 +63,13 @@ cluster: ## Create a K3D Kubernetes cluster with load balancer and registry
 cluster-rm: ## Remove a K3D Kubernetes cluster
 	$(info Removing Kubernetes cluster...)
 	k3d cluster delete nyu-devops
+
+.PHONY: seed-postgres
+seed-postgres: ## Mirror the postgres image into the local cluster-registry
+	$(info Seeding $(POSTGRES_IMAGE) into $(REGISTRY)...)
+	docker pull $(POSTGRES_IMAGE)
+	docker tag $(POSTGRES_IMAGE) $(REGISTRY)/$(POSTGRES_IMAGE)
+	docker push $(REGISTRY)/$(POSTGRES_IMAGE)
 
 .PHONY: deploy
 deploy: ## Deploy the service on local Kubernetes

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # These can be overidden with env vars.
 REGISTRY ?= cluster-registry:5000
-IMAGE_NAME ?= petshop
+IMAGE_NAME ?= products
 IMAGE_TAG ?= 1.0
 IMAGE ?= $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
 POSTGRES_IMAGE ?= postgres:15

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,25 @@ secret: ## Generate a secret hex key
 .PHONY: cluster
 cluster: ## Create a K3D Kubernetes cluster with load balancer and registry
 	$(info Creating Kubernetes cluster $(CLUSTER) with a registry and 2 worker nodes...)
-	k3d cluster create $(CLUSTER) --agents 2 --registry-create cluster-registry:0.0.0.0:5000 --port '8080:80@loadbalancer'
+	k3d cluster create --config k3d-config.yaml
+
+.PHONY: preflight
+preflight: ## Verify local machine is configured to push to cluster-registry:5000
+	$(info Checking local preflight requirements...)
+	@getent hosts cluster-registry >/dev/null 2>&1 || { \
+		echo "ERROR: hostname 'cluster-registry' does not resolve locally."; \
+		echo "       Add this line to /etc/hosts (needs sudo):"; \
+		echo "         127.0.0.1 cluster-registry"; \
+		exit 1; \
+	}
+	@docker info 2>/dev/null | grep -q 'cluster-registry:5000' || { \
+		echo "ERROR: docker daemon is missing cluster-registry:5000 from insecure-registries."; \
+		echo "       Write /etc/docker/daemon.json (needs sudo):"; \
+		echo "         {\"insecure-registries\": [\"cluster-registry:5000\"]}"; \
+		echo "       Then: sudo systemctl restart docker   (or restart Docker Desktop)"; \
+		exit 1; \
+	}
+	@echo "Preflight OK: cluster-registry resolves and docker treats it as insecure."
 
 .PHONY: cluster-rm
 cluster-rm: ## Remove a K3D Kubernetes cluster
@@ -65,7 +83,7 @@ cluster-rm: ## Remove a K3D Kubernetes cluster
 	k3d cluster delete nyu-devops
 
 .PHONY: seed-postgres
-seed-postgres: ## Mirror the postgres image into the local cluster-registry
+seed-postgres: preflight ## Mirror the postgres image into the local cluster-registry
 	$(info Seeding $(POSTGRES_IMAGE) into $(REGISTRY)...)
 	docker pull $(POSTGRES_IMAGE)
 	docker tag $(POSTGRES_IMAGE) $(REGISTRY)/$(POSTGRES_IMAGE)
@@ -95,7 +113,7 @@ build:	## Build the project container image for local platform
 	docker build --rm --pull --tag $(IMAGE) .
 
 .PHONY: push
-push:	## Push the image to the container registry
+push: preflight	## Push the image to the container registry
 	$(info Pushing $(IMAGE)...)
 	docker push $(IMAGE)
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,27 @@ Check code style against PEP8:
 make lint
 ```
 
+## Local Kubernetes Deployment
+
+Deploy the full stack (products service + PostgreSQL) to a local K3D cluster.
+Both images — the products container and `postgres:15` — are served from the
+in-cluster `cluster-registry:5000` so that `kubectl apply` always pulls via a
+registry (this avoids a known containerd/k3d issue with `k3d image import`
+and multi-manifest attestation digests).
+
+```bash
+make cluster          # create K3D cluster with load balancer + registry
+make seed-postgres    # pull postgres:15 and push it to cluster-registry
+make build            # build the products image
+make push             # push the products image to cluster-registry
+make deploy           # kubectl apply -R -f k8s/
+```
+
+Once the pods are ready, the service is reachable through the ingress at
+`http://localhost:8080/` (e.g. `curl http://localhost:8080/health`).
+
+Tear down with `make cluster-rm`.
+
 ## API Endpoints
 
 ### Root Endpoint

--- a/README.md
+++ b/README.md
@@ -78,7 +78,33 @@ in-cluster `cluster-registry:5000` so that `kubectl apply` always pulls via a
 registry (this avoids a known containerd/k3d issue with `k3d image import`
 and multi-manifest attestation digests).
 
+### One-time local setup
+
+The cluster registry is plain HTTP, which the local Docker daemon refuses by
+default. Two one-time machine-level tweaks are required before `make push` /
+`make seed-postgres` work. `make preflight` validates both and prints the
+exact fix command if something is missing.
+
+1. Let the local docker CLI resolve `cluster-registry` to the loopback address:
+
+   ```bash
+   echo "127.0.0.1 cluster-registry" | sudo tee -a /etc/hosts
+   ```
+
+2. Tell the docker daemon that `cluster-registry:5000` is an insecure
+   (plain-HTTP) registry, then restart docker:
+
+   ```bash
+   sudo tee /etc/docker/daemon.json <<'EOF'
+   {"insecure-registries": ["cluster-registry:5000"]}
+   EOF
+   sudo systemctl restart docker    # or restart Docker Desktop
+   ```
+
+### Deploy sequence
+
 ```bash
+make preflight        # sanity-check the two host-level tweaks above
 make cluster          # create K3D cluster with load balancer + registry
 make seed-postgres    # pull postgres:15 and push it to cluster-registry
 make build            # build the products image

--- a/k3d-config.yaml
+++ b/k3d-config.yaml
@@ -1,0 +1,20 @@
+apiVersion: k3d.io/v1alpha5
+kind: Simple
+metadata:
+  name: nyu-devops
+servers: 1
+agents: 2
+ports:
+  - port: 8080:80
+    nodeFilters:
+      - loadbalancer
+registries:
+  create:
+    name: cluster-registry
+    host: "0.0.0.0"
+    hostPort: "5000"
+  config: |
+    mirrors:
+      "cluster-registry:5000":
+        endpoint:
+          - http://cluster-registry:5000

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: products
+  labels:
+    app: products
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: products
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: products
+    spec:
+      restartPolicy: Always
+      containers:
+        - name: products
+          image: cluster-registry:5000/petshop:1.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: PORT
+              value: "8080"
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_DB
+            - name: DATABASE_URI
+              value: postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@postgres:5432/$(POSTGRES_DB)
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: products
-          image: cluster-registry:5000/petshop:1.0
+          image: cluster-registry:5000/products:1.0
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                   name: postgres-secret
                   key: POSTGRES_DB
             - name: DATABASE_URI
-              value: postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@postgres:5432/$(POSTGRES_DB)
+              value: postgresql+psycopg://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@postgres:5432/$(POSTGRES_DB)
           readinessProbe:
             httpGet:
               path: /health

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: products
+  labels:
+    app: products
+  annotations:
+    kubernetes.io/ingress.class: traefik
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: products
+                port:
+                  number: 8080

--- a/k8s/postgres/postgres-statefulset.yaml
+++ b/k8s/postgres/postgres-statefulset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: postgres:15
+          image: cluster-registry:5000/postgres:15
           ports:
             - containerPort: 5432
           env:

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: products
+  labels:
+    app: products
+spec:
+  type: ClusterIP
+  selector:
+    app: products
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: http


### PR DESCRIPTION
Covers both story #28 (Create Kubernetes Deployment Manifests) and story #29 (Update Makefile and Verify Local K8s Deployment). The two stories are tightly coupled — the #28 manifests cannot be verified without #29's buildable image and Makefile wiring — so they were delivered together and verified end-to-end on a local K3D cluster.

## Changes

### Story #28 — Kubernetes manifests
- `k8s/deployment.yaml` — products Deployment (port 8080, `postgres-secret` env, `/health` probes)
- `k8s/service.yaml` — ClusterIP Service on :8080
- `k8s/ingress.yaml` — Traefik Ingress routing `/` to the products service
- `k8s/deployment.yaml` DATABASE_URI uses `postgresql+psycopg://` so SQLAlchemy picks the psycopg3 driver that Pipfile ships (bare `postgresql://` resolves to psycopg2, which is not installed)

### Story #29 — Makefile and image name
- `Makefile` — `IMAGE_NAME` is now `products` (was `petshop`); image is `cluster-registry:5000/products:1.0`
- `k8s/deployment.yaml` — image field updated to match
- `Makefile` — new `make seed-postgres` target pulls, tags, and pushes `postgres:15` into the in-cluster registry so a fresh clone can bring up the stack with a single documented sequence

### Reproducibility for other cluster operators
A classmate hit `ImagePullBackOff: http: server gave HTTP response to HTTPS client` after recreating their K3D cluster. The root cause is that each K3s node needs `/etc/rancher/k3s/registries.yaml` declaring `cluster-registry:5000` as an `http://` endpoint; `k3d cluster create --registry-create` *usually* injects this but can silently drop the config depending on k3d version and platform. To remove that variability:

- `k3d-config.yaml` (new) — checked-in k3d `v1alpha5` Simple config. Creates the registry inline **and** declares `registries.config` verbatim, so every node receives the correct `registries.yaml` unconditionally. Verified after `make cluster-rm && make cluster` that all three nodes have the file with the right mirrors block.
- `make cluster` reads `k3d-config.yaml` instead of passing flags.
- `make preflight` (new) — validates the two host-level prerequisites (`cluster-registry` in `/etc/hosts` and docker daemon `insecure-registries`) and prints the exact fix if either is missing. `make push` and `make seed-postgres` depend on it, so the error surfaces up-front instead of during an opaque TLS handshake inside containerd.
- `README.md` — new **One-time local setup** subsection walks through the `/etc/hosts` and `/etc/docker/daemon.json` edits; the deploy sequence leads with `make preflight`.

### Supporting changes
- `Dockerfile` + `.dockerignore` — python:3.12-slim, `pipenv sync --system`, gunicorn on :8080, non-root user. Required so `make build` succeeds.
- `k8s/postgres/postgres-statefulset.yaml` — image now `cluster-registry:5000/postgres:15` so both our service image and postgres flow through the same in-cluster registry. Mirrors the coursework push-to-registry workflow and avoids a known containerd/k3d bug where multi-manifest attestation digests cause `content digest not found` during `k3d image import`.

## End-to-end verification (from clean slate)
Ran `make cluster-rm` then `make preflight / cluster / seed-postgres / build / push / deploy`. All three cluster nodes received the correct `/etc/rancher/k3s/registries.yaml`:
```yaml
mirrors:
  cluster-registry:5000:
    endpoint:
    - http://cluster-registry:5000
```
Pods reached Running:
```
postgres-0                 1/1  Running
products-b6b574f95-597mh   1/1  Running   cluster-registry:5000/products:1.0
products-b6b574f95-khh2l   1/1  Running   cluster-registry:5000/products:1.0
```
Ingress responses via `http://localhost:8080`:
- `GET /health` → `200 {"status":"OK"}`
- `POST /products` → `201` with created `id`
- `GET /products` → round-trips the persisted payload

## Reproduce
```bash
# one-time host setup (see README for details)
make preflight
make cluster
make seed-postgres
make build
make push
make deploy
curl http://localhost:8080/health
```

## Test plan
- [x] `make preflight` passes; fails loud with exact fix command when `/etc/hosts` or insecure-registries is missing
- [x] `make cluster` from clean slate injects `registries.yaml` on every node
- [x] `kubectl apply -R -f k8s/` succeeds on a local K3D cluster
- [x] `postgres-0` reaches Ready (1/1) pulling from `cluster-registry:5000/postgres:15`
- [x] `products` Deployment reaches desired replicas pulling `cluster-registry:5000/products:1.0` with **no ImagePullBackOff**
- [x] `/health` returns 200 through the ingress
- [x] Full CRUD round-trips through the ingress into postgres
- [x] `make cluster / seed-postgres / build / push / deploy` succeeds as a single sequence (AC for #29)
- [ ] CI (lint, pytest, codecov >= 95%) passes — no `service/` code changed