### PR TITLE
Add admin UI page for listing all products

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Admin UI pages:
 - `http://localhost:8080/admin/products/create` — Add a new product to the catalog.
 - `http://localhost:8080/admin/products/update` — Retrieve a product by id, edit fields, and submit updates.
 - `http://localhost:8080/admin/products/delete` — Delete a product by id.
+- `http://localhost:8080/admin/products/list` — View all products in the catalog.
 
 ## Running Tests
 
@@ -152,6 +153,15 @@ Renders a lightweight admin page that supports:
 - entering a product id
 - deleting the product and viewing a success message
 - displaying an error if the product does not exist
+
+### Admin Product List UI
+
+`GET /admin/products/list`
+
+Renders a lightweight admin page that supports:
+- pressing a "List All" button to retrieve every product
+- displaying results in a table with id, name, category, price, stock, and availability
+- showing a message when no products exist
 
 ### Admin Product Update UI
 

--- a/features/list_product_ui.feature
+++ b/features/list_product_ui.feature
@@ -1,0 +1,16 @@
+Feature: List products from admin UI
+  As an eCommerce manager
+  I need the ability to list all products from the admin UI
+  So that I can view the current catalog without using the API directly
+
+  Scenario: List all products when products exist
+    Given multiple products exist in the database
+    And I am on the "List Products" admin page
+    When I press the "List All" button
+    Then I should see all products displayed in the results area
+
+  Scenario: Show a message when no products exist
+    Given no products exist in the database
+    And I am on the "List Products" admin page
+    When I press the "List All" button
+    Then I should see a message indicating no products were found

--- a/service/routes.py
+++ b/service/routes.py
@@ -67,6 +67,12 @@ def admin_read_product_page():
     return render_template("admin_product_read.html"), status.HTTP_200_OK
 
 
+@app.route("/admin/products/list", methods=["GET"])
+def admin_list_product_page():
+    """Render the admin UI for listing all products."""
+    return render_template("admin_product_list.html"), status.HTTP_200_OK
+
+
 ######################################################################
 #  R E S T   A P I   E N D P O I N T S
 ######################################################################

--- a/service/static/admin_product_list.css
+++ b/service/static/admin_product_list.css
@@ -1,0 +1,89 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #f6f8fb;
+  color: #1f2937;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.container {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 2rem 1rem 3rem;
+}
+
+.page-header h1 {
+  margin: 0 0 0.5rem;
+}
+
+.page-header p {
+  margin: 0 0 1.5rem;
+  color: #4b5563;
+}
+
+.card {
+  background: #ffffff;
+  border: 1px solid #dbe3ec;
+  border-radius: 10px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.card h2 {
+  margin: 0 0 0.8rem;
+  font-size: 1rem;
+}
+
+button {
+  font: inherit;
+  border: 1px solid #1d4ed8;
+  background: #2563eb;
+  color: #ffffff;
+  border-radius: 8px;
+  padding: 0.55rem 0.9rem;
+  cursor: pointer;
+}
+
+.message {
+  min-height: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 0.8rem;
+}
+
+.message.success {
+  color: #166534;
+}
+
+.message.error {
+  color: #b91c1c;
+}
+
+.empty-state {
+  color: #6b7280;
+  font-style: italic;
+}
+
+.products-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.products-table th,
+.products-table td {
+  text-align: left;
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.products-table th {
+  background: #f9fafb;
+  font-size: 0.85rem;
+  color: #374151;
+}
+
+.products-table tr:last-child td {
+  border-bottom: none;
+}

--- a/service/static/admin_product_list.js
+++ b/service/static/admin_product_list.js
@@ -1,0 +1,75 @@
+(function initAdminListPage() {
+  "use strict";
+
+  var listAllButton = document.getElementById("list-all-button");
+  var message = document.getElementById("message");
+  var emptyState = document.getElementById("empty-state");
+  var productsTable = document.getElementById("products-table");
+  var productsTbody = document.getElementById("products-tbody");
+
+  function showMessage(text, type) {
+    message.textContent = text;
+    message.className = "message";
+    if (type) {
+      message.classList.add(type);
+    }
+  }
+
+  function clearResults() {
+    productsTbody.innerHTML = "";
+    productsTable.hidden = true;
+    emptyState.hidden = false;
+  }
+
+  function renderProducts(products) {
+    productsTbody.innerHTML = "";
+
+    if (products.length === 0) {
+      productsTable.hidden = true;
+      emptyState.hidden = false;
+      emptyState.textContent = "No products found.";
+      showMessage("No products exist in the catalog.", "error");
+      return;
+    }
+
+    emptyState.hidden = true;
+    productsTable.hidden = false;
+
+    for (var i = 0; i < products.length; i++) {
+      var p = products[i];
+      var row = document.createElement("tr");
+      row.innerHTML =
+        "<td>" + p.id + "</td>" +
+        "<td>" + (p.name || "") + "</td>" +
+        "<td>" + (p.category || "") + "</td>" +
+        "<td>" + (p.price || "") + "</td>" +
+        "<td>" + (p.stock != null ? p.stock : "") + "</td>" +
+        "<td>" + (p.available ? "Yes" : "No") + "</td>";
+      productsTbody.appendChild(row);
+    }
+
+    showMessage(products.length + " product(s) found.", "success");
+  }
+
+  async function listAllProducts() {
+    clearResults();
+    showMessage("Loading products...", null);
+
+    var response = await fetch("/products", { method: "GET" });
+    var payload = await response.json().catch(function () { return null; });
+
+    if (!response.ok) {
+      showMessage("Failed to retrieve products.", "error");
+      return;
+    }
+
+    renderProducts(payload || []);
+  }
+
+  listAllButton.addEventListener("click", function onListAllClick() {
+    listAllProducts().catch(function onListError() {
+      clearResults();
+      showMessage("Unexpected error while listing products.", "error");
+    });
+  });
+})();

--- a/service/templates/admin_product_list.html
+++ b/service/templates/admin_product_list.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Admin Product List</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='admin_product_list.css') }}" />
+  </head>
+  <body>
+    <main class="container">
+      <header class="page-header">
+        <h1>List Products</h1>
+        <p>View all products in the catalog.</p>
+      </header>
+
+      <section class="card">
+        <h2>Actions</h2>
+        <button id="list-all-button" type="button">List All</button>
+      </section>
+
+      <section id="message" class="message" aria-live="polite"></section>
+
+      <section class="card">
+        <h2>Results</h2>
+        <div id="results-area">
+          <p id="empty-state" class="empty-state">Press "List All" to load products.</p>
+          <table id="products-table" class="products-table" hidden>
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Name</th>
+                <th>Category</th>
+                <th>Price</th>
+                <th>Stock</th>
+                <th>Available</th>
+              </tr>
+            </thead>
+            <tbody id="products-tbody"></tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+
+    <script src="{{ url_for('static', filename='admin_product_list.js') }}"></script>
+  </body>
+</html>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -119,6 +119,15 @@ class TestProductService(TestCase):
         self.assertIn("Read Product", page)
         self.assertIn("Retrieve Product", page)
 
+    def test_admin_list_product_page(self):
+        """It should render the admin list product UI page"""
+        response = self.client.get("/admin/products/list")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("text/html", response.content_type)
+        page = response.get_data(as_text=True)
+        self.assertIn("List Products", page)
+        self.assertIn("List All", page)
+
     def test_404_not_found(self):
         """It should return 404 JSON for an unknown route"""
         resp = self.client.get("/nonexistent-route")


### PR DESCRIPTION
## Summary

- Added admin UI page at `GET /admin/products/list` to list all products in the catalog
- UI displays products in a table with id, name, category, price, stock, and availability
- Shows appropriate message when no products exist
- Added route test and BDD feature file for list functionality
- Updated README with admin list UI endpoint and documentation

## Local Testing Note

If testing locally in the DevContainer, remember to initialize the database first:

```bash
flask db-create
```

Then optionally seed a product to verify the table renders:

```bash
curl -X POST http://localhost:8080/products -H "Content-Type: application/json"   -d '{"name": "Test Widget", "description": "A test product", "price": "19.99", "category": "Electronics", "available": true, "stock": 10}'
```

## Test plan

- [x] `GET /admin/products/list` returns 200 with HTML page
- [x] "List All" button fetches and displays all products in a table
- [x] Shows "No products found" message when catalog is empty
- [x] Route test passes
- [x] BDD feature file added

Closes #45