### PR TITLE
Add admin category filter for product list

### DIFF
--- a/features/list_product_ui.feature
+++ b/features/list_product_ui.feature
@@ -14,3 +14,9 @@ Feature: List products from admin UI
     And I am on the "List Products" admin page
     When I press the "List All" button
     Then I should see a message indicating no products were found
+
+  Scenario: Filter products by category
+    Given products exist in categories "Electronics" and "Clothing"
+    And I am on the "List Products" admin page
+    When I enter "Electronics" in the category field and press the "Query" button
+    Then I should see only products in the "Electronics" category displayed in the results area

--- a/service/static/admin_product_list.css
+++ b/service/static/admin_product_list.css
@@ -47,6 +47,36 @@ button {
   cursor: pointer;
 }
 
+.actions-row {
+  margin-bottom: 1rem;
+}
+
+.query-row {
+  display: grid;
+  grid-template-columns: 100px minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.query-row label {
+  font-weight: 600;
+}
+
+.query-row input {
+  width: 100%;
+  font: inherit;
+  color: inherit;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 0.55rem 0.75rem;
+  background: #ffffff;
+}
+
+.query-row input:focus {
+  outline: 2px solid #93c5fd;
+  outline-offset: 1px;
+}
+
 .message {
   min-height: 1.5rem;
   font-weight: 600;
@@ -86,4 +116,10 @@ button {
 
 .products-table tr:last-child td {
   border-bottom: none;
+}
+
+@media (max-width: 640px) {
+  .query-row {
+    grid-template-columns: 1fr;
+  }
 }

--- a/service/static/admin_product_list.js
+++ b/service/static/admin_product_list.js
@@ -2,6 +2,8 @@
   "use strict";
 
   var listAllButton = document.getElementById("list-all-button");
+  var queryButton = document.getElementById("query-button");
+  var categoryInput = document.getElementById("category-input");
   var message = document.getElementById("message");
   var emptyState = document.getElementById("empty-state");
   var productsTable = document.getElementById("products-table");
@@ -21,14 +23,20 @@
     emptyState.hidden = false;
   }
 
-  function renderProducts(products) {
+  function renderProducts(products, context) {
     productsTbody.innerHTML = "";
+    context = context || { mode: "list" };
 
     if (products.length === 0) {
       productsTable.hidden = true;
       emptyState.hidden = false;
-      emptyState.textContent = "No products found.";
-      showMessage("No products exist in the catalog.", "error");
+      if (context.mode === "category") {
+        emptyState.textContent = 'No products found for category "' + context.value + '".';
+        showMessage('No products found for category "' + context.value + '".', "error");
+      } else {
+        emptyState.textContent = "No products found.";
+        showMessage("No products exist in the catalog.", "error");
+      }
       return;
     }
 
@@ -48,7 +56,14 @@
       productsTbody.appendChild(row);
     }
 
-    showMessage(products.length + " product(s) found.", "success");
+    if (context.mode === "category") {
+      showMessage(
+        products.length + ' product(s) found for category "' + context.value + '".',
+        "success"
+      );
+    } else {
+      showMessage(products.length + " product(s) found.", "success");
+    }
   }
 
   async function listAllProducts() {
@@ -63,7 +78,32 @@
       return;
     }
 
-    renderProducts(payload || []);
+    renderProducts(payload || [], { mode: "list" });
+  }
+
+  async function queryProductsByCategory() {
+    var category = categoryInput.value.trim();
+
+    if (!category) {
+      clearResults();
+      emptyState.textContent = 'Enter a category and press "Query" to search.';
+      showMessage("Enter a category to query products.", "error");
+      return;
+    }
+
+    clearResults();
+    showMessage('Loading products for category "' + category + '"...', null);
+
+    var params = new URLSearchParams({ category: category });
+    var response = await fetch("/products?" + params.toString(), { method: "GET" });
+    var payload = await response.json().catch(function () { return null; });
+
+    if (!response.ok) {
+      showMessage("Failed to retrieve products.", "error");
+      return;
+    }
+
+    renderProducts(payload || [], { mode: "category", value: category });
   }
 
   listAllButton.addEventListener("click", function onListAllClick() {
@@ -71,5 +111,19 @@
       clearResults();
       showMessage("Unexpected error while listing products.", "error");
     });
+  });
+
+  queryButton.addEventListener("click", function onQueryClick() {
+    queryProductsByCategory().catch(function onQueryError() {
+      clearResults();
+      showMessage("Unexpected error while querying products.", "error");
+    });
+  });
+
+  categoryInput.addEventListener("keydown", function onCategoryKeydown(event) {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      queryButton.click();
+    }
   });
 })();

--- a/service/templates/admin_product_list.html
+++ b/service/templates/admin_product_list.html
@@ -15,7 +15,20 @@
 
       <section class="card">
         <h2>Actions</h2>
-        <button id="list-all-button" type="button">List All</button>
+        <div class="actions-row">
+          <button id="list-all-button" type="button">List All</button>
+        </div>
+        <div class="query-row">
+          <label for="category-input">Category</label>
+          <input
+            id="category-input"
+            name="category"
+            type="text"
+            placeholder="Enter a category"
+            autocomplete="off"
+          />
+          <button id="query-button" type="button">Query</button>
+        </div>
       </section>
 
       <section id="message" class="message" aria-live="polite"></section>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -127,6 +127,8 @@ class TestProductService(TestCase):
         page = response.get_data(as_text=True)
         self.assertIn("List Products", page)
         self.assertIn("List All", page)
+        self.assertIn("Category", page)
+        self.assertIn("Query", page)
 
     def test_admin_purchase_product_page(self):
         """It should render the admin purchase product UI page"""


### PR DESCRIPTION
## Summary
- add a category input and Query button to the admin list UI
- query the existing `/products` endpoint with the `category` query parameter
- show matching products in the results area and a no-results message when nothing matches
- add a BDD scenario for filtering by category

## Testing
- not run in this environment (`pytest` is not installed)