### PR TITLE
Set up BDD test environment with Behave and Selenium for Story #30

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,21 +13,18 @@ python-dotenv = "~=1.2.1"
 gunicorn = "~=25.0.0"
 
 [dev-packages]
-# Code Quality
 pylint = "~=4.0.4"
 flake8 = "~=7.3.0"
 black = "~=26.1.0"
-
-# Test-Driven Development
 pytest = "~=9.0.2"
 pytest-pspec = "~=0.0.4"
 pytest-cov = "~=7.0.0"
 factory-boy = "~=3.3.3"
 coverage = "~=7.13.2"
-
-# Utility
 honcho = "~=2.0.0"
 httpie = "~=3.2.4"
+behave = "*"
+selenium = "*"
 
 [requires]
 python_version = "3.12"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b9f819918554391616bf459cf3c01a5eee896ec489a758cab9cb1604c0ebec1a"
+            "sha256": "e4337cec78da83be7dbe4c7bb3c08049ee5b201bd0b41c1c20073df020a4fb15"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -367,6 +367,23 @@
             "markers": "python_full_version >= '3.10.0'",
             "version": "==4.0.3"
         },
+        "attrs": {
+            "hashes": [
+                "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309",
+                "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==26.1.0"
+        },
+        "behave": {
+            "hashes": [
+                "sha256:2b8f4b64ed2ea756a5a2a73e23defc1c4631e9e724c499e46661778453ebaf51",
+                "sha256:89bdb62af8fb9f147ce245736a5de69f025e5edfb66f1fbe16c5007493f842c0"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==1.3.3"
+        },
         "black": {
             "hashes": [
                 "sha256:101540cb2a77c680f4f80e628ae98bd2bd8812fb9d72ade4f8995c5ff019e82c",
@@ -403,11 +420,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c",
-                "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"
+                "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa",
+                "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2026.1.4"
+            "version": "==2026.2.25"
         },
         "charset-normalizer": {
             "hashes": [
@@ -536,6 +553,14 @@
             "markers": "python_version >= '3.10'",
             "version": "==8.3.1"
         },
+        "colorama": {
+            "hashes": [
+                "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
+                "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
+            "version": "==0.4.6"
+        },
         "coverage": {
             "extras": [
                 "toml"
@@ -638,6 +663,22 @@
             "markers": "python_version >= '3.10'",
             "version": "==7.13.2"
         },
+        "cucumber-expressions": {
+            "hashes": [
+                "sha256:8eb5ae46dd03dd37fec1163ace1510529501d7d1868ff372c1ab2cd5aa4543a8",
+                "sha256:f452e6c73258c1677043ad67ad5f538c87284d6b502004720510fb6b7452d9c5"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==19.0.0"
+        },
+        "cucumber-tag-expressions": {
+            "hashes": [
+                "sha256:cca145d677a942c1877e5a2cf13da8c6ec99260988877c817efd284d8455bb56",
+                "sha256:d960383d5885300ebcbcb14e41657946fde2a59d5c0f485eb291bc6a0e228acc"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==9.1.0"
+        },
         "defusedxml": {
             "hashes": [
                 "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69",
@@ -680,6 +721,14 @@
             "markers": "python_version >= '3.9'",
             "version": "==7.3.0"
         },
+        "h11": {
+            "hashes": [
+                "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1",
+                "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.16.0"
+        },
         "honcho": {
             "hashes": [
                 "sha256:56dcd04fc72d362a4befb9303b1a1a812cba5da283526fbc6509be122918ddf3",
@@ -699,11 +748,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea",
-                "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"
+                "sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67",
+                "sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.11"
+            "version": "==3.12"
         },
         "iniconfig": {
             "hashes": [
@@ -905,6 +954,14 @@
             "markers": "python_version >= '3.8'",
             "version": "==1.1.0"
         },
+        "outcome": {
+            "hashes": [
+                "sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8",
+                "sha256:e771c5ce06d1415e356078d3bdd68523f284b4ce5419828922b6871e65eda82b"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.3.0.post0"
+        },
         "packaging": {
             "hashes": [
                 "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4",
@@ -912,6 +969,21 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==26.0"
+        },
+        "parse": {
+            "hashes": [
+                "sha256:55339ca698019815df3b8e8b550e5933933527e623b0cdf1ca2f404da35ffb47",
+                "sha256:825e1a88e9d9fb481b8d2ca709c6195558b6eaa97c559ad3a9a20aa2d12815a3"
+            ],
+            "version": "==1.21.1"
+        },
+        "parse-type": {
+            "hashes": [
+                "sha256:3ca79bbe71e170dfccc8ec6c341edfd1c2a0fc1e5cfd18330f93af938de2348c",
+                "sha256:513a3784104839770d690e04339a8b4d33439fcd5dd99f2e4580f9fc1097bfb2"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1'",
+            "version": "==0.6.6"
         },
         "pathspec": {
             "hashes": [
@@ -1088,6 +1160,15 @@
             "markers": "python_full_version >= '3.8.0'",
             "version": "==14.3.2"
         },
+        "selenium": {
+            "hashes": [
+                "sha256:4f97639055dcfa9eadf8ccf549ba7b0e49c655d4e2bde19b9a44e916b754e769",
+                "sha256:bada5c08a989f812728a4b5bea884d8e91894e939a441cc3a025201ce718581e"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==4.43.0"
+        },
         "setuptools": {
             "hashes": [
                 "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70",
@@ -1104,6 +1185,21 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.17.0"
         },
+        "sniffio": {
+            "hashes": [
+                "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2",
+                "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.3.1"
+        },
+        "sortedcontainers": {
+            "hashes": [
+                "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88",
+                "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"
+            ],
+            "version": "==2.4.0"
+        },
         "tomlkit": {
             "hashes": [
                 "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680",
@@ -1112,13 +1208,56 @@
             "markers": "python_version >= '3.9'",
             "version": "==0.14.0"
         },
+        "trio": {
+            "hashes": [
+                "sha256:3bd5d87f781d9b0192d592aef28691f8951d6c2e41b7e1da4c25cde6c180ae9b",
+                "sha256:a29b92b73f09d4b48ed249acd91073281a7f1063f09caba5dc70465b5c7aa970"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==0.33.0"
+        },
+        "trio-websocket": {
+            "hashes": [
+                "sha256:22c72c436f3d1e264d0910a3951934798dcc5b00ae56fc4ee079d46c7cf20fae",
+                "sha256:df605665f1db533f4a386c94525870851096a223adcb97f72a07e8b4beba45b6"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.12.2"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
+                "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==4.15.0"
+        },
         "urllib3": {
+            "extras": [
+                "socks"
+            ],
             "hashes": [
                 "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
                 "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
             ],
             "markers": "python_version >= '3.9'",
             "version": "==2.6.3"
+        },
+        "websocket-client": {
+            "hashes": [
+                "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98",
+                "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.9.0"
+        },
+        "wsproto": {
+            "hashes": [
+                "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584",
+                "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==1.3.2"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -289,3 +289,12 @@ Copyright (c) 2016, 2025 [John Rofrano](https://www.linkedin.com/in/JohnRofrano/
 Licensed under the Apache License. See [LICENSE](LICENSE)
 
 This repository is part of the New York University (NYU) masters class: **CSCI-GA.2820-001 DevOps and Agile Methodologies** created and taught by [John Rofrano](https://cs.nyu.edu/~rofrano/), Adjunct Instructor, NYU Courant Institute, Graduate Division, Computer Science, and NYU Stern School of Business.
+
+## Running BDD Tests
+
+This project uses **Behave** and **Selenium** for browser-based BDD testing.
+
+### Install BDD dependencies
+
+```bash
+pipenv install --dev behave selenium

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,0 +1,44 @@
+"""
+Behave environment setup for Selenium WebDriver
+"""
+
+import os
+import shutil
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.chrome.service import Service
+
+
+def before_all(context):
+    """Set up Selenium before the test run."""
+    context.base_url = os.getenv("BASE_URL", "http://localhost:8080")
+
+    chrome_options = Options()
+    chrome_options.add_argument("--headless=new")
+    chrome_options.add_argument("--no-sandbox")
+    chrome_options.add_argument("--disable-dev-shm-usage")
+    chrome_options.add_argument("--window-size=1280,1024")
+
+    browser_path = None
+    for browser_name in ["chromium", "chromium-browser", "google-chrome"]:
+        path = shutil.which(browser_name)
+        if path:
+            browser_path = path
+            break
+
+    if browser_path:
+        chrome_options.binary_location = browser_path
+
+    chromedriver_path = shutil.which("chromedriver")
+    if not chromedriver_path:
+        raise RuntimeError("chromedriver not found. Please install chromium-driver.")
+
+    service = Service(chromedriver_path)
+    context.driver = webdriver.Chrome(service=service, options=chrome_options)
+    context.driver.implicitly_wait(5)
+
+
+def after_all(context):
+    """Clean up Selenium after the test run."""
+    if hasattr(context, "driver"):
+        context.driver.quit()

--- a/features/setup_bdd_ui.feature
+++ b/features/setup_bdd_ui.feature
@@ -1,0 +1,14 @@
+Feature: BDD test environment setup
+  As a developer
+  I need Behave configured with Selenium
+  So that the team can run UI-based BDD tests
+
+  Scenario: Open the list products admin page
+    Given I am on the "List Products" admin page
+    Then I should see the heading "List Products"
+    And I should see the button with id "list-all-button"
+
+  Scenario: Open the purchase product admin page
+    Given I am on the "Purchase Product" admin page
+    Then I should see the heading "Purchase Product"
+    And I should see the button with id "purchase-button"

--- a/features/steps/web_steps.py
+++ b/features/steps/web_steps.py
@@ -1,0 +1,38 @@
+"""
+Step definitions for BDD Selenium setup checks
+"""
+from behave import given, then
+from selenium.webdriver.common.by import By
+
+
+PAGE_URLS = {
+    "List Products": "/admin/products/list",
+    "Purchase Product": "/admin/products/purchase",
+    "Create Product": "/admin/products/create",
+    "Read Product": "/admin/products/read",
+    "Update Product": "/admin/products/update",
+    "Delete Product": "/admin/products/delete",
+}
+
+
+@given('I am on the "{page_name}" admin page')
+def step_open_admin_page(context, page_name):
+    """Open the requested admin page."""
+    path = PAGE_URLS[page_name]
+    context.driver.get(f"{context.base_url}{path}")
+
+
+@then('I should see the heading "{heading_text}"')
+def step_see_heading(context, heading_text):
+    """Verify the page heading is visible."""
+    heading = context.driver.find_element(By.TAG_NAME, "h1")
+    assert heading.text.strip() == heading_text, (
+        f'Expected heading "{heading_text}" but found "{heading.text.strip()}"'
+    )
+
+
+@then('I should see the button with id "{button_id}"')
+def step_see_button(context, button_id):
+    """Verify a button exists on the page."""
+    button = context.driver.find_element(By.ID, button_id)
+    assert button.is_displayed(), f'Button with id "{button_id}" is not visible'


### PR DESCRIPTION
Implements Story #30: Set Up BDD Test Environment with Behave and Selenium

What was added:
- Added Behave and Selenium as dev dependencies
- Created features/environment.py to initialize Selenium WebDriver
- Created features/steps/web_steps.py for browser-based step definitions
- Added a simple setup feature file to verify the framework initializes and Selenium connects to the UI
- Updated README with instructions for running BDD tests

How to test:
1. Start the service with `export PORT=8080 && make run`
2. Run `BASE_URL=http://localhost:8081 pipenv run behave features/setup_bdd_ui.feature`

This setup uses the web interface only and does not call the service directly from the BDD test.

Closes #30