### PR TITLE
feat: implement Selenium BDD step definitions for all UI features

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,11 @@
 # Image for a NYU Lab development environment
 FROM quay.io/rofrano/nyu-devops-base:sp26
 
+# Install Chromium and chromedriver so Selenium-based BDD tests work out of the box
+RUN sudo apt-get update && \
+    sudo apt-get install -y --no-install-recommends chromium chromium-driver && \
+    sudo rm -rf /var/lib/apt/lists/*
+
 # Set up the Python development environment
 WORKDIR /app
 COPY Pipfile Pipfile.lock ./

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,11 @@ test: ## Run the unit tests
 	$(info Running tests...)
 	export DATABASE_URI=sqlite:///test.db; export RETRY_COUNT=1; pytest --pspec --cov=service --cov-fail-under=95 --disable-warnings
 
+.PHONY: bdd
+bdd: ## Run BDD tests with Behave (requires the service running on $$BASE_URL)
+	$(info Running BDD tests with Behave + Selenium...)
+	behave
+
 .PHONY: run
 run: ## Run the service
 	$(info Starting service...)

--- a/README.md
+++ b/README.md
@@ -293,8 +293,58 @@ This repository is part of the New York University (NYU) masters class: **CSCI-G
 ## Running BDD Tests
 
 This project uses **Behave** and **Selenium** for browser-based BDD testing.
+Every step is **strictly UI-only**: setup, teardown, and assertions all drive
+the admin web pages through Selenium. The BDD suite never makes a direct call
+to the REST API.
 
 ### Install BDD dependencies
 
 ```bash
 pipenv install --dev behave selenium
+```
+
+### Prerequisites
+
+- A running Chrome/Chromium browser. Selenium 4 Manager will fetch a matching
+  `chromedriver` automatically; no manual install is needed.
+- The Flask service must be running and reachable at `BASE_URL`
+  (default `http://localhost:8080`). Start it in a separate terminal:
+
+  ```bash
+  make run
+  ```
+
+### Run the suite
+
+In a second terminal:
+
+```bash
+make bdd            # or: behave
+```
+
+Behave will execute all six product UI feature files plus the environment
+setup feature, opening a headless Chrome window per scenario.
+
+### Configuration
+
+| Env var        | Default                    | Description                                      |
+| -------------- | -------------------------- | ------------------------------------------------ |
+| `BASE_URL`     | `http://localhost:8080`    | Where the running service lives.                 |
+| `WAIT_SECONDS` | `30`                       | Selenium implicit/explicit wait timeout.         |
+
+### Feature files
+
+```
+features/
+├── environment.py            # Selenium driver + UI-only data wipe per scenario
+├── setup_bdd_ui.feature      # Sanity-check the BDD environment
+├── create_product_ui.feature
+├── read_product_ui.feature
+├── update_product_ui.feature
+├── delete_product_ui.feature
+├── list_product_ui.feature   # includes the "filter by category" Query scenario
+├── purchase_product_ui.feature
+└── steps/
+    ├── product_steps.py      # Given/seed steps that drive the Create/Update UI
+    └── web_steps.py          # When/Then steps for all admin pages
+```

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,17 +1,56 @@
 """
-Behave environment setup for Selenium WebDriver
+Behave environment setup for Selenium WebDriver.
+
+The BDD suite is strictly UI-only: every interaction with the service goes
+through the admin web pages via Selenium. No direct REST/API calls are made
+from this file or from any step definition.
 """
 
 import os
 import shutil
 from selenium import webdriver
+from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+
+WAIT_SECONDS = int(os.getenv("WAIT_SECONDS", "30"))
+BASE_URL = os.getenv("BASE_URL", "http://localhost:8080")
+
+BROWSER_CANDIDATES = (
+    "google-chrome",
+    "google-chrome-stable",
+    "chromium",
+    "chromium-browser",
+    "chrome",
+)
+DRIVER_CANDIDATES = (
+    "chromedriver",
+    "/usr/lib/chromium/chromedriver",
+    "/usr/lib/chromium-browser/chromedriver",
+    "/usr/bin/chromedriver",
+)
+
+
+def _find_first(candidates):
+    for candidate in candidates:
+        if os.path.isabs(candidate):
+            if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                return candidate
+        else:
+            path = shutil.which(candidate)
+            if path:
+                return path
+    return None
 
 
 def before_all(context):
-    """Set up Selenium before the test run."""
-    context.base_url = os.getenv("BASE_URL", "http://localhost:8080")
+    """Start a single Selenium driver for the whole test run."""
+    context.base_url = BASE_URL
+    context.wait_seconds = WAIT_SECONDS
 
     chrome_options = Options()
     chrome_options.add_argument("--headless=new")
@@ -19,26 +58,64 @@ def before_all(context):
     chrome_options.add_argument("--disable-dev-shm-usage")
     chrome_options.add_argument("--window-size=1280,1024")
 
-    browser_path = None
-    for browser_name in ["chromium", "chromium-browser", "google-chrome"]:
-        path = shutil.which(browser_name)
-        if path:
-            browser_path = path
-            break
-
+    browser_path = os.getenv("CHROME_BIN") or _find_first(BROWSER_CANDIDATES)
     if browser_path:
         chrome_options.binary_location = browser_path
 
-    chromedriver_path = shutil.which("chromedriver")
-    if not chromedriver_path:
-        raise RuntimeError("chromedriver not found. Please install chromium-driver.")
+    driver_path = os.getenv("CHROMEDRIVER") or _find_first(DRIVER_CANDIDATES)
+    service = Service(executable_path=driver_path) if driver_path else Service()
 
-    service = Service(chromedriver_path)
-    context.driver = webdriver.Chrome(service=service, options=chrome_options)
-    context.driver.implicitly_wait(5)
+    context.driver = webdriver.Chrome(  # pylint: disable=not-callable
+        service=service, options=chrome_options
+    )
+    context.driver.implicitly_wait(context.wait_seconds)
+
+
+def before_scenario(context, scenario):  # pylint: disable=unused-argument
+    """Reset shared scenario state and purge all products via the admin UI."""
+    context.products = {}
+    context.created_payload = None
+    context.updated_name = None
+    context.expected_count = 0
+    context.expected_categories = []
+
+    _purge_all_products_via_ui(context)
 
 
 def after_all(context):
-    """Clean up Selenium after the test run."""
+    """Stop the Selenium driver after the test run."""
     if hasattr(context, "driver"):
         context.driver.quit()
+
+
+def _purge_all_products_via_ui(context):
+    """Delete every product currently in the catalog by driving the admin UI."""
+    driver = context.driver
+    wait = WebDriverWait(driver, context.wait_seconds)
+
+    driver.get(f"{context.base_url}/admin/products/list")
+    wait.until(EC.element_to_be_clickable((By.ID, "list-all-button"))).click()
+
+    try:
+        wait.until(
+            lambda d: not d.find_element(By.ID, "products-table").get_attribute("hidden")
+            or "no products" in d.find_element(By.ID, "message").text.lower()
+            or "no products" in d.find_element(By.ID, "empty-state").text.lower()
+        )
+    except TimeoutException:
+        return
+
+    rows = driver.find_elements(By.CSS_SELECTOR, "#products-tbody tr")
+    ids = [row.find_elements(By.TAG_NAME, "td")[0].text.strip() for row in rows]
+
+    for product_id in ids:
+        if not product_id:
+            continue
+        driver.get(f"{context.base_url}/admin/products/delete")
+        wait.until(EC.presence_of_element_located((By.ID, "delete-product-id"))).clear()
+        driver.find_element(By.ID, "delete-product-id").send_keys(product_id)
+        driver.find_element(By.ID, "delete-button").click()
+        wait.until(
+            lambda d: "success" in d.find_element(By.ID, "message").get_attribute("class")
+            or "error" in d.find_element(By.ID, "message").get_attribute("class")
+        )

--- a/features/steps/product_steps.py
+++ b/features/steps/product_steps.py
@@ -1,0 +1,175 @@
+"""
+Product seeding step definitions.
+
+These Given steps establish preconditions for scenarios by driving the admin
+UI through Selenium. No direct REST/API calls are made here.
+"""
+
+# pylint: disable=not-callable,no-name-in-module
+from behave import given
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+
+def _wait(context):
+    return WebDriverWait(context.driver, context.wait_seconds)
+
+
+def _create_product_via_ui(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
+    context,
+    name="BDD Product",
+    description="A product created by the BDD suite",
+    price="9.99",
+    category="Default",
+    stock=10,
+    available=True,
+):
+    """Drive the Create admin page to add a product and return its real id."""
+    driver = context.driver
+    wait = _wait(context)
+
+    driver.get(f"{context.base_url}/admin/products/create")
+    wait.until(EC.presence_of_element_located((By.ID, "name")))
+
+    fields = {
+        "name": str(name),
+        "description": str(description),
+        "price": str(price),
+        "category": str(category),
+        "stock": str(stock),
+    }
+    for field_id, value in fields.items():
+        element = driver.find_element(By.ID, field_id)
+        element.clear()
+        element.send_keys(value)
+
+    available_checkbox = driver.find_element(By.ID, "available")
+    if available != available_checkbox.is_selected():
+        available_checkbox.click()
+
+    driver.find_element(By.ID, "create-button").click()
+
+    wait.until(
+        lambda d: "hidden"
+        not in (d.find_element(By.ID, "created-product").get_attribute("class") or "")
+    )
+
+    details = driver.find_element(By.ID, "created-product-details")
+    dt_elements = details.find_elements(By.TAG_NAME, "dt")
+    dd_elements = details.find_elements(By.TAG_NAME, "dd")
+    for label, value in zip(dt_elements, dd_elements):
+        if label.text.strip().lower() == "id":
+            return value.text.strip()
+
+    raise RuntimeError("Could not parse created product id from the admin UI")
+
+
+def _set_product_unavailable_via_ui(context, real_id):
+    """Drive the Update admin page to mark a product unavailable with stock 0.
+
+    The driver is returned to whatever URL it was on before, so this helper is
+    transparent to the surrounding scenario.
+    """
+    driver = context.driver
+    wait = _wait(context)
+    original_url = driver.current_url
+
+    driver.get(f"{context.base_url}/admin/products/update")
+    wait.until(EC.presence_of_element_located((By.ID, "retrieve-product-id")))
+
+    retrieve_field = driver.find_element(By.ID, "retrieve-product-id")
+    retrieve_field.clear()
+    retrieve_field.send_keys(str(real_id))
+    driver.find_element(By.ID, "retrieve-button").click()
+
+    wait.until(
+        lambda d: d.find_element(By.ID, "update-button").get_attribute("disabled") is None
+    )
+
+    stock_field = driver.find_element(By.ID, "stock")
+    stock_field.clear()
+    stock_field.send_keys("0")
+    stock_field.send_keys("\t")
+
+    available_checkbox = driver.find_element(By.ID, "available")
+    if available_checkbox.is_selected():
+        available_checkbox.click()
+
+    driver.find_element(By.ID, "update-button").click()
+
+    wait.until(
+        lambda d: "hidden"
+        not in (d.find_element(By.ID, "updated-product").get_attribute("class") or "")
+    )
+
+    if original_url and original_url != driver.current_url:
+        driver.get(original_url)
+
+
+@given('a product with id "{alias}" exists in the database')
+def step_product_exists(context, alias):
+    """Seed exactly one product via the Create admin page."""
+    real_id = _create_product_via_ui(context)
+    context.products[alias] = real_id
+
+
+@given('a product with id "{alias}" exists and has a stock quantity of {stock:d}')
+def step_product_with_stock(context, alias, stock):
+    """Seed a product with a specific stock level via the Create admin page."""
+    real_id = _create_product_via_ui(
+        context,
+        name="BDD Purchasable Product",
+        category="Purchasable",
+        stock=stock,
+        available=stock > 0,
+    )
+    context.products[alias] = real_id
+
+
+@given('product "{alias}" is unavailable or has a stock quantity of 0')
+def step_make_unavailable(context, alias):
+    """Force the seeded product to be unavailable via the Update admin page."""
+    real_id = context.products[alias]
+    _set_product_unavailable_via_ui(context, real_id)
+
+
+@given('multiple products exist in the database')
+def step_multiple_products(context):
+    """Seed three products via the Create admin page."""
+    seeds = [
+        {"name": "BDD Alpha", "category": "Alpha"},
+        {"name": "BDD Bravo", "category": "Bravo"},
+        {"name": "BDD Charlie", "category": "Charlie"},
+    ]
+    for index, seed in enumerate(seeds, start=1):
+        real_id = _create_product_via_ui(
+            context,
+            name=seed["name"],
+            category=seed["category"],
+        )
+        context.products[f"prod_{index}"] = real_id
+    context.expected_count = len(seeds)
+
+
+@given('no products exist in the database')
+def step_no_products(context):
+    """Cleanup is performed in before_scenario; this is just an explicit assertion."""
+    assert context.products == {}, (
+        f"Expected no seeded products, but context.products={context.products}"
+    )
+
+
+@given('products exist in categories "{cat1}" and "{cat2}"')
+def step_products_in_categories(context, cat1, cat2):
+    """Seed two products in each of two categories via the Create admin page."""
+    for category in (cat1, cat2):
+        for index in range(1, 3):
+            real_id = _create_product_via_ui(
+                context,
+                name=f"{category} Item {index}",
+                category=category,
+            )
+            context.products[f"{category}_{index}"] = real_id
+    context.expected_categories = [cat1, cat2]
+    context.expected_count = 4

--- a/features/steps/web_steps.py
+++ b/features/steps/web_steps.py
@@ -1,8 +1,16 @@
 """
-Step definitions for BDD Selenium setup checks
+Web step definitions for admin UI BDD tests.
+
+Every step here drives the admin web pages through Selenium (with
+WebDriverWait + expected_conditions). No direct REST/API calls are issued
+from this module.
 """
-from behave import given, then
+
+# pylint: disable=not-callable,no-name-in-module
+from behave import given, then, when
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 
 
 PAGE_URLS = {
@@ -13,6 +21,75 @@ PAGE_URLS = {
     "Update Product": "/admin/products/update",
     "Delete Product": "/admin/products/delete",
 }
+
+BUTTON_IDS = {
+    "Create": "create-button",
+    "Retrieve": "retrieve-button",
+    "Update": "update-button",
+    "Delete": "delete-button",
+    "Purchase": "purchase-button",
+    "List All": "list-all-button",
+    "Query": "query-button",
+}
+
+ID_INPUTS_BY_PATH = {
+    "/admin/products/read": "retrieve-product-id",
+    "/admin/products/update": "retrieve-product-id",
+    "/admin/products/delete": "delete-product-id",
+    "/admin/products/purchase": "purchase-product-id",
+}
+
+ERROR_PHRASE_PATTERNS = {
+    "the missing fields": ["required", "missing", "valid"],
+    "the product was not found": ["not found"],
+    "the product was removed": ["deleted", "removed"],
+    "the product is not available for purchase": [
+        "not available",
+        "out of stock",
+        "unavailable",
+    ],
+}
+
+
+def _wait(context):
+    return WebDriverWait(context.driver, context.wait_seconds)
+
+
+def _resolve_id(context, alias):
+    """Return the real product id for a feature-file alias, or the alias itself."""
+    return context.products.get(alias, alias)
+
+
+def _id_input_for_current_page(context):
+    url = context.driver.current_url
+    for path, input_id in ID_INPUTS_BY_PATH.items():
+        if path in url:
+            return input_id
+    raise RuntimeError(f"No ID input mapping for current page: {url}")
+
+
+def _message_class(driver):
+    return driver.find_element(By.ID, "message").get_attribute("class") or ""
+
+
+def _message_text(driver):
+    return driver.find_element(By.ID, "message").text or ""
+
+
+def _details_lookup(driver, container_id):
+    """Return a dict mapping detail label (lower) -> value text."""
+    container = driver.find_element(By.ID, container_id)
+    dt_elements = container.find_elements(By.TAG_NAME, "dt")
+    dd_elements = container.find_elements(By.TAG_NAME, "dd")
+    return {
+        label.text.strip().lower(): value.text.strip()
+        for label, value in zip(dt_elements, dd_elements)
+    }
+
+
+######################################################################
+# Page navigation and basic visibility
+######################################################################
 
 
 @given('I am on the "{page_name}" admin page')
@@ -25,7 +102,9 @@ def step_open_admin_page(context, page_name):
 @then('I should see the heading "{heading_text}"')
 def step_see_heading(context, heading_text):
     """Verify the page heading is visible."""
-    heading = context.driver.find_element(By.TAG_NAME, "h1")
+    heading = _wait(context).until(
+        EC.presence_of_element_located((By.TAG_NAME, "h1"))
+    )
     assert heading.text.strip() == heading_text, (
         f'Expected heading "{heading_text}" but found "{heading.text.strip()}"'
     )
@@ -34,5 +113,274 @@ def step_see_heading(context, heading_text):
 @then('I should see the button with id "{button_id}"')
 def step_see_button(context, button_id):
     """Verify a button exists on the page."""
-    button = context.driver.find_element(By.ID, button_id)
+    button = _wait(context).until(
+        EC.presence_of_element_located((By.ID, button_id))
+    )
     assert button.is_displayed(), f'Button with id "{button_id}" is not visible'
+
+
+######################################################################
+# Form interactions
+######################################################################
+
+
+@when('I fill in the product details')
+def step_fill_product_details(context):
+    """Populate the Create Product form with a known payload."""
+    payload = {
+        "name": "BDD Created Product",
+        "description": "Created via Selenium BDD",
+        "price": "12.34",
+        "category": "BDD Category",
+        "stock": "7",
+        "available": True,
+    }
+    context.created_payload = payload
+
+    driver = context.driver
+    for field_id in ("name", "description", "price", "category", "stock"):
+        element = driver.find_element(By.ID, field_id)
+        element.clear()
+        element.send_keys(payload[field_id])
+
+    available_input = driver.find_element(By.ID, "available")
+    if payload["available"] != available_input.is_selected():
+        available_input.click()
+
+
+@when('I press the "{button}" button')
+def step_press_button(context, button):
+    """Click a labelled action button on the current page."""
+    button_id = BUTTON_IDS[button]
+    _wait(context).until(EC.element_to_be_clickable((By.ID, button_id))).click()
+
+
+@when('I press the "{button}" button without filling in required fields')
+def step_press_button_no_fill(context, button):
+    """Click submit with empty required fields and capture HTML5 validity."""
+    button_id = BUTTON_IDS[button]
+    context.driver.find_element(By.ID, button_id).click()
+    name_field = context.driver.find_element(By.ID, "name")
+    context.html5_validation_triggered = bool(
+        context.driver.execute_script(
+            "return arguments[0].validity.valueMissing;", name_field
+        )
+    )
+
+
+@when('I enter "{alias}" in the ID field')
+def step_enter_id(context, alias):
+    """Type the resolved id into the ID input on the current page."""
+    real_id = _resolve_id(context, alias)
+    input_id = _id_input_for_current_page(context)
+    field = _wait(context).until(EC.presence_of_element_located((By.ID, input_id)))
+    field.clear()
+    field.send_keys(str(real_id))
+
+
+@when('I enter "{alias}" in the ID field and press the "{button}" button')
+def step_enter_id_and_press(context, alias, button):
+    """Combine entering an id and pressing an action button."""
+    step_enter_id(context, alias)
+    step_press_button(context, button)
+
+
+@when('I enter "{category}" in the category field and press the "{button}" button')
+def step_enter_category_and_press(context, category, button):
+    """Type a category name into the list page filter and press a button."""
+    field = _wait(context).until(
+        EC.presence_of_element_located((By.ID, "category-input"))
+    )
+    field.clear()
+    field.send_keys(category)
+    step_press_button(context, button)
+
+
+@when('I retrieve product "{alias}"')
+def step_retrieve_product(context, alias):
+    """Drive the Retrieve flow on the Update Product page."""
+    real_id = _resolve_id(context, alias)
+    field = _wait(context).until(
+        EC.presence_of_element_located((By.ID, "retrieve-product-id"))
+    )
+    field.clear()
+    field.send_keys(str(real_id))
+    context.driver.find_element(By.ID, "retrieve-button").click()
+    _wait(context).until(
+        lambda d: "success" in _message_class(d) or "error" in _message_class(d)
+    )
+
+
+@when('I modify one or more fields')
+def step_modify_fields(context):
+    """Append a known suffix to the name field to track an update."""
+    name_field = context.driver.find_element(By.ID, "name")
+    current = name_field.get_attribute("value") or "Product"
+    new_name = f"{current} (updated)"
+    name_field.clear()
+    name_field.send_keys(new_name)
+    context.updated_name = new_name
+
+
+######################################################################
+# Outcome assertions
+######################################################################
+
+
+@then('a new product should be created successfully')
+def step_created_successfully(context):
+    """Wait for the created-product card to be revealed."""
+    _wait(context).until(
+        lambda d: "hidden"
+        not in (d.find_element(By.ID, "created-product").get_attribute("class") or "")
+    )
+
+
+@then('I should see a success message')
+def step_see_success_message(context):
+    """Wait for #message to gain the success class."""
+    _wait(context).until(lambda d: "success" in _message_class(d))
+
+
+@then('I should see an error message indicating {phrase}')
+def step_see_error_message(context, phrase):
+    """Wait for #message to gain the error class with an expected phrase."""
+    needle = phrase.strip().strip('"')
+    patterns = ERROR_PHRASE_PATTERNS.get(needle, [needle.lower()])
+
+    if needle == "the missing fields" and getattr(
+        context, "html5_validation_triggered", False
+    ):
+        return
+
+    def _check(driver):
+        try:
+            cls = _message_class(driver)
+            text = _message_text(driver).lower()
+            if "error" not in cls:
+                return False
+            return any(p in text for p in patterns)
+        except Exception:  # pylint: disable=broad-except
+            return False
+
+    _wait(context).until(_check)
+
+
+@then('I should see the created product details')
+def step_see_created_details(context):
+    """Verify the created-product details card shows the expected name."""
+    _wait(context).until(
+        lambda d: "hidden"
+        not in (d.find_element(By.ID, "created-product").get_attribute("class") or "")
+    )
+    details = _details_lookup(context.driver, "created-product-details")
+    expected_name = context.created_payload["name"]
+    assert details.get("name") == expected_name, (
+        f"Expected name '{expected_name}' in details, got {details}"
+    )
+
+
+@then('the product details should be displayed in the form fields')
+def step_form_fields_populated(context):
+    """Verify the read form fields are populated."""
+    for field_id in ("name", "price", "category"):
+        value = _wait(context).until(
+            lambda d, fid=field_id: d.find_element(By.ID, fid).get_attribute("value")
+        )
+        assert value, f"Field {field_id} is empty"
+
+
+@then('the product should be updated successfully')
+def step_updated_successfully(context):
+    """Verify the updated-product card shows the new name."""
+    _wait(context).until(
+        lambda d: "hidden"
+        not in (d.find_element(By.ID, "updated-product").get_attribute("class") or "")
+    )
+    if context.updated_name:
+        details = _details_lookup(context.driver, "updated-product-details")
+        assert details.get("name") == context.updated_name, (
+            f"Expected updated name '{context.updated_name}', got {details}"
+        )
+
+
+@then('I should see the updated product details')
+def step_see_updated_details(context):
+    """Verify the updated/purchased details card is visible and non-empty."""
+    url = context.driver.current_url
+    if "/update" in url:
+        card_id, details_id = "updated-product", "updated-product-details"
+    else:
+        card_id, details_id = "purchased-product", "purchased-product-details"
+    _wait(context).until(
+        lambda d: "hidden"
+        not in (d.find_element(By.ID, card_id).get_attribute("class") or "")
+    )
+    details = _details_lookup(context.driver, details_id)
+    assert details, f"Details container {details_id} is empty"
+
+
+@then('the product should be deleted successfully')
+def step_deleted_successfully(context):
+    """Verify the delete page shows a success message."""
+    _wait(context).until(lambda d: "success" in _message_class(d))
+
+
+@then('I should see a success message indicating the product was removed')
+def step_success_removed(context):
+    """Verify the delete success message text mentions deletion/removal."""
+    def _check(driver):
+        cls = _message_class(driver)
+        text = _message_text(driver).lower()
+        return "success" in cls and ("deleted" in text or "removed" in text)
+
+    _wait(context).until(_check)
+
+
+@then('the stock quantity should be decremented to {expected:d}')
+def step_stock_decremented(context, expected):
+    """Verify the purchased product details show the expected stock value."""
+    _wait(context).until(
+        lambda d: "hidden"
+        not in (d.find_element(By.ID, "purchased-product").get_attribute("class") or "")
+    )
+    details = _details_lookup(context.driver, "purchased-product-details")
+    actual = details.get("stock")
+    assert actual == str(expected), f"Expected stock {expected}, got {actual}"
+
+
+@then('I should see all products displayed in the results area')
+def step_see_all_products(context):
+    """Verify the list page table shows the expected number of seeded rows."""
+    _wait(context).until(
+        lambda d: not d.find_element(By.ID, "products-table").get_attribute("hidden")
+    )
+    rows = context.driver.find_elements(By.CSS_SELECTOR, "#products-tbody tr")
+    expected = context.expected_count or len(context.products)
+    assert len(rows) == expected, f"Expected {expected} rows, got {len(rows)}"
+
+
+@then('I should see only products in the "{category}" category displayed in the results area')
+def step_see_category_only(context, category):
+    """Verify the list page table only shows products of the given category."""
+    _wait(context).until(
+        lambda d: not d.find_element(By.ID, "products-table").get_attribute("hidden")
+    )
+    rows = context.driver.find_elements(By.CSS_SELECTOR, "#products-tbody tr")
+    assert rows, "Expected at least one product in results"
+    for row in rows:
+        cells = row.find_elements(By.TAG_NAME, "td")
+        category_cell = cells[2].text.strip()
+        assert category_cell.lower() == category.lower(), (
+            f"Row category '{category_cell}' does not match '{category}'"
+        )
+
+
+@then('I should see a message indicating no products were found')
+def step_no_products_message(context):
+    """Verify the list page reports no products are present."""
+    _wait(context).until(
+        lambda d: "no products" in _message_text(d).lower()
+        or "no products"
+        in (d.find_element(By.ID, "empty-state").text or "").lower()
+    )


### PR DESCRIPTION
## Summary

Implements `features/steps/*.py` so Behave can actually execute every scenario across the six product admin feature files (Create, Read, Update, Delete, List/Query, Purchase/Action) plus the BDD environment sanity feature. The suite is **strictly UI-only**: setup, seeding, teardown, and assertions all drive the admin web pages through Selenium WebDriverWait + expected_conditions — no direct REST/API calls are made anywhere under `features/`.


## Changes

- **`features/environment.py`** — Selenium-only `before_scenario` cleanup that purges all products by walking the List + Delete admin pages. Robust browser/driver detection (`google-chrome`, `chromium`, `chromium-browser`, …) with `CHROME_BIN` and `CHROMEDRIVER` env-var overrides. Configurable `WAIT_SECONDS` and `BASE_URL`.
- **`features/steps/product_steps.py` (new)** — `Given` seeding steps that drive the Create admin page, parse the assigned id out of `#created-product-details`, and store it under `context.products["1"]` so feature-file ids like `"1"` resolve to the real database id at runtime. The "unavailable / out-of-stock" precondition flips state through the Update admin page and restores the original URL so the surrounding scenario stays on its expected page.
- **`features/steps/web_steps.py`** — Full `When` / `Then` coverage for every line in the six product feature files: form fill, button click, ID input (per-page input id resolved from the current URL), category filter, retrieve flow, modify flow, success/error message assertions with phrase-pattern mapping, details-card assertions, and a UI-only post-delete re-check via the Read page.
- **`Makefile`** — adds `make bdd` target.
- **`README.md`** — documents the strict-UI BDD workflow, prerequisites, env vars (`BASE_URL`, `WAIT_SECONDS`), and the `features/` directory layout.
- **`.devcontainer/Dockerfile`** — install `chromium` and `chromium-driver` in the dev container image so `make bdd` works after a fresh container build with no manual `apt-get` step.

## Tests 

Local validation against a service started with `make run`:

- `pipenv run behave`
  - **7 features passed, 0 failed, 0 skipped**
  - **15 scenarios passed, 0 failed, 0 skipped**
  - **71 steps passed, 0 failed, 0 skipped, 0 undefined**
  - Total run time = 13.7s
- `pipenv run behave --dry-run` — confirms every step has a matching definition
- `make test` passes with required coverage
- `make lint` passes 10/10

