### PR TITLE
Feature/openshift postgres

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 .git
 .github
 .vscode
-.devcontainer
 .pytest_cache
 .coverage
 __pycache__

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,8 @@ seed-postgres: preflight ## Mirror the postgres image into the local cluster-reg
 .PHONY: deploy
 deploy: ## Deploy the service on local Kubernetes
 	$(info Deploying service locally...)
-	kubectl apply -R -f k8s/
+	kubectl apply -f k8s/
+	kubectl apply -f k8s/postgres/
 
 ############################################################
 # COMMANDS FOR BUILDING THE IMAGE

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ make cluster          # create K3D cluster with load balancer + registry
 make seed-postgres    # pull postgres:15 and push it to cluster-registry
 make build            # build the products image
 make push             # push the products image to cluster-registry
-make deploy           # kubectl apply -R -f k8s/
+make deploy           # kubectl apply -f k8s/ && kubectl apply -f k8s/postgres/
 ```
 
 Once the pods are ready, the service is reachable through the ingress at

--- a/k8s/openshift/postgres/pvc.yaml
+++ b/k8s/openshift/postgres/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/k8s/openshift/postgres/secret.yaml
+++ b/k8s/openshift/postgres/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-secret
+type: Opaque
+stringData:
+  POSTGRES_DB: products
+  POSTGRES_USER: postgres
+  POSTGRES_PASSWORD: postgres

--- a/k8s/openshift/postgres/service.yaml
+++ b/k8s/openshift/postgres/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  type: ClusterIP
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/k8s/openshift/postgres/statefulset.yaml
+++ b/k8s/openshift/postgres/statefulset.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  serviceName: "postgres"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        fsGroupChangePolicy: "OnRootMismatch"
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_DB
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_PASSWORD
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          readinessProbe:
+            exec:
+              command: ["pg_isready"]
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command: ["pg_isready"]
+            initialDelaySeconds: 45
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: postgres-storage
+              mountPath: /var/lib/postgresql/data
+            - name: postgres-run
+              mountPath: /var/run/postgresql
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "256Mi"
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+      volumes:
+        - name: postgres-storage
+          persistentVolumeClaim:
+            claimName: postgres-pvc
+        - name: postgres-run
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}


### PR DESCRIPTION
## Summary

Adds OpenShift-flavored PostgreSQL manifests under `k8s/openshift/postgres/` so the products microservice has a persistent database in the Red Hat OpenShift Developer Sandbox. Same `postgres-secret` keys (`POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB`) as the local k3d setup so the application config doesn't need to change between environments.

## Changes

- **`k8s/openshift/postgres/`** — new manifests for the OpenShift sandbox:
  - `secret.yaml`, `pvc.yaml`, `service.yaml` (ClusterIP `postgres:5432`), `statefulset.yaml`..
- **`Makefile` + `README.md`** — `make deploy` no longer recurses into `k8s/openshift/`. The previous `kubectl apply -R -f k8s/` is changed and now it applies the local set explicitly: top-level `k8s/*.yaml` plus `k8s/postgres/`.

- **`.dockerignore`** . The dev container Dockerfile copies `.devcontainer/scripts/install-tools.sh`, which BuildKit was filtering out. 


## Tests

Manually verified on the OpenShift Developer Sandbox (`aa12938-dev`); local `make test` and `make lint` pass.

- **Pod status** — `oc apply -f k8s/openshift/postgres/` brought `postgres-0` to `1/1 Running`; PVC bound 1 Gi RWO on the sandbox default StorageClass.
- **Service reachability** — a throwaway `pgcheck` pod connected via `psql postgresql://postgres:postgres@postgres:5432/products` and `SELECT 1` returned `1`, proving DNS, secret values, and the `products` database all line up.
- **Secret keys** — `oc get secret postgres-secret` showed `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`; base64-decoded values match the local k3d secret exactly.
- **Persistence** — inserted a row into a `smoke` table, ran `oc delete pod postgres-0`, the StatefulSet brought it back, and the same row was readable from the new pod.
