### PR TITLE
Add OpenShift Route for products service

### DIFF
--- a/k8s/openshift/route.yaml
+++ b/k8s/openshift/route.yaml
@@ -1,0 +1,16 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: products
+  labels:
+    app: products
+spec:
+  port:
+    targetPort: http
+  to:
+    kind: Service
+    name: products
+    weight: 100
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect


### PR DESCRIPTION
## Summary

- Adds an OpenShift Route manifest at `k8s/openshift/route.yaml` that exposes the products ClusterIP service externally on port 8080
- TLS edge termination with insecure traffic redirected to HTTPS
- Route targets the named port `http` on the `products` service

## Details

The route is placed under `k8s/openshift/` alongside the existing postgres manifests, keeping OpenShift-specific resources separate from the local k3d setup. The `make deploy` command (which only applies `k8s/` and `k8s/postgres/`) is unaffected.

## Acceptance Criteria

- [x] Route resource points to products ClusterIP service on port 8080
- [ ] Route is active with an assigned URL after `oc apply -f k8s/openshift/route.yaml`
- [ ] GET `<route-url>/health` returns 200 with `{"status":"OK"}`
- [ ] Full CRUD operations work through the route URL

Closes #61