### PR TITLE
Add Tekton BDD test task

### DIFF
--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -63,3 +63,27 @@ spec:
       script: |
         buildah bud --format=oci -t $(params.IMAGE_NAME) .
         buildah push --tls-verify=false $(params.IMAGE_NAME)
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: bdd
+spec:
+  params:
+    - name: BASE_URL
+      type: string
+      description: The route URL of the deployed products service
+  workspaces:
+    - name: source
+  steps:
+    - name: bdd-tests
+      image: python:3.12-slim
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: BASE_URL
+          value: $(params.BASE_URL)
+      script: |
+        apt-get update && apt-get install -y chromium chromium-driver
+        pip install pipenv
+        pipenv install --system --dev
+        behave


### PR DESCRIPTION
## Summary
- Adds a new Tekton `Task` named `bdd` to `.tekton/tasks.yaml`
- Task takes a `BASE_URL` parameter pointing to the deployed products service
- Installs Chromium and ChromeDriver, then runs `behave` with Selenium against the live deployment

Closes #67

## Test plan
- [ ] Verify the task YAML is valid by applying it to the cluster
- [ ] Run the BDD task after a successful deploy and confirm all scenarios pass