### PR TITLE
Create Tekton pipeline definition

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -1,0 +1,91 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: cd-pipeline
+spec:
+  workspaces:
+    - name: pipeline-workspace
+  params:
+    - name: repo-url
+      type: string
+      description: The git repository URL to clone
+    - name: branch
+      type: string
+      description: The git branch to clone
+      default: master
+    - name: image-name
+      type: string
+      description: The image to build and deploy
+      default: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/products:latest
+    - name: base-url
+      type: string
+      description: The route URL for BDD tests
+
+  tasks:
+    - name: clone
+      taskRef:
+        name: git-clone
+        kind: ClusterTask
+      workspaces:
+        - name: output
+          workspace: pipeline-workspace
+      params:
+        - name: url
+          value: $(params.repo-url)
+        - name: revision
+          value: $(params.branch)
+
+    - name: lint
+      runAfter:
+        - clone
+      taskRef:
+        name: lint
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+
+    - name: tests
+      runAfter:
+        - clone
+      taskRef:
+        name: tests
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+
+    - name: build
+      runAfter:
+        - lint
+        - tests
+      taskRef:
+        name: build
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+      params:
+        - name: IMAGE_NAME
+          value: $(params.image-name)
+
+    - name: deploy
+      runAfter:
+        - build
+      taskRef:
+        name: deploy
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+      params:
+        - name: IMAGE_NAME
+          value: $(params.image-name)
+
+    - name: bdd
+      runAfter:
+        - deploy
+      taskRef:
+        name: bdd
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+      params:
+        - name: BASE_URL
+          value: $(params.base-url)

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -34,7 +34,8 @@ spec:
           value: $(params.repo-url)
         - name: revision
           value: $(params.branch)
-
+        - name: deleteExisting      
+          value: "true"  
     - name: lint
       runAfter:
         - clone


### PR DESCRIPTION
Closes #68

Created `.tekton/pipeline.yaml` with the full Tekton CD pipeline.

The pipeline defines 6 tasks: clone, lint, tests, build, deploy, and bdd.

Lint and tests run in parallel after clone.
Build runs after lint and tests pass.
Deploy runs after build.
BDD runs after deploy.