### PR TITLE
Add Tekton EventListener, TriggerBinding, and TriggerTemplate

### DIFF
--- a/.tekton/event-listener.yaml
+++ b/.tekton/event-listener.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-triggers-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-triggers-sa-binding
+subjects:
+  - kind: ServiceAccount
+    name: tekton-triggers-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-triggers-eventlistener-roles
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: cd-pipeline-listener
+spec:
+  serviceAccountName: tekton-triggers-sa
+  triggers:
+    - name: github-push
+      interceptors:
+        - ref:
+            name: cel
+          params:
+            - name: filter
+              value: "header.match('X-GitHub-Event', 'push') && body.ref == 'refs/heads/master'"
+            - name: overlays
+              value:
+                - key: branch_name
+                  expression: "body.ref.split('/')[2]"
+      bindings:
+        - ref: github-push-binding
+      template:
+        ref: cd-pipeline-template
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: cd-pipeline-listener
+spec:
+  to:
+    kind: Service
+    name: el-cd-pipeline-listener
+  port:
+    targetPort: http-listener

--- a/.tekton/event-listener.yaml
+++ b/.tekton/event-listener.yaml
@@ -1,40 +1,15 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: tekton-triggers-sa
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: tekton-triggers-sa-binding
-subjects:
-  - kind: ServiceAccount
-    name: tekton-triggers-sa
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: tekton-triggers-eventlistener-roles
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: tekton-triggers-sa-clusterbinding
-subjects:
-  - kind: ServiceAccount
-    name: tekton-triggers-sa
-    # Change "default" to your namespace before applying on OpenShift.
-    namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: tekton-triggers-eventlistener-clusterroles
----
 apiVersion: triggers.tekton.dev/v1beta1
 kind: EventListener
 metadata:
   name: cd-pipeline-listener
 spec:
-  serviceAccountName: tekton-triggers-sa
+  # On OpenShift, the 'pipeline' ServiceAccount is auto-provisioned by the
+  # OpenShift Pipelines operator in every namespace where Tekton resources
+  # are used, and already has the right cluster-scoped read access for
+  # ClusterInterceptors and ClusterTriggerBindings, plus permission to
+  # create PipelineRuns. Reusing it avoids needing custom Roles or
+  # ClusterRoleBindings that regular users cannot grant on Developer Sandbox.
+  serviceAccountName: pipeline
   triggers:
     - name: github-push
       interceptors:
@@ -62,3 +37,6 @@ spec:
     name: el-cd-pipeline-listener
   port:
     targetPort: http-listener
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/.tekton/event-listener.yaml
+++ b/.tekton/event-listener.yaml
@@ -15,6 +15,20 @@ roleRef:
   kind: ClusterRole
   name: tekton-triggers-eventlistener-roles
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-triggers-sa-clusterbinding
+subjects:
+  - kind: ServiceAccount
+    name: tekton-triggers-sa
+    # Change "default" to your namespace before applying on OpenShift.
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-triggers-eventlistener-clusterroles
+---
 apiVersion: triggers.tekton.dev/v1beta1
 kind: EventListener
 metadata:

--- a/.tekton/trigger-binding.yaml
+++ b/.tekton/trigger-binding.yaml
@@ -1,0 +1,10 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerBinding
+metadata:
+  name: github-push-binding
+spec:
+  params:
+    - name: repo-url
+      value: $(body.repository.clone_url)
+    - name: branch
+      value: $(extensions.branch_name)

--- a/.tekton/trigger-template.yaml
+++ b/.tekton/trigger-template.yaml
@@ -1,0 +1,30 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: cd-pipeline-template
+spec:
+  params:
+    - name: repo-url
+      description: The git repository URL to clone
+    - name: branch
+      description: The git branch to check out
+      default: master
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: cd-pipeline-run-
+      spec:
+        pipelineRef:
+          name: cd-pipeline
+        params:
+          - name: repo-url
+            value: $(tt.params.repo-url)
+          - name: branch
+            value: $(tt.params.branch)
+          - name: base-url
+            value: http://products:8080
+        workspaces:
+          - name: pipeline-workspace
+            persistentVolumeClaim:
+              claimName: pipeline-workspace


### PR DESCRIPTION
Closes #69

## Summary
Adds the three Tekton Triggers resources that wire a GitHub push webhook to the existing `cd-pipeline`. All files live under `.tekton/` per the AC.

- **`.tekton/trigger-binding.yaml`** — `TriggerBinding github-push-binding` extracts `repo-url` from `body.repository.clone_url` and `branch` from the CEL overlay `extensions.branch_name` (computed in the EventListener so the binding sees a clean `master` instead of `refs/heads/master`).
- **`.tekton/trigger-template.yaml`** — `TriggerTemplate cd-pipeline-template` generates a PipelineRun (`generateName: cd-pipeline-run-`) that references `pipelineRef: cd-pipeline`, passes `repo-url` and `branch` from the binding, hardcodes `base-url` to the in-cluster service URL `http://products:8080` (so the BDD task can reach the deployed service from inside the cluster), and binds `pipeline-workspace` to the existing PVC of the same name.
- **`.tekton/event-listener.yaml`** — bundles the `ServiceAccount tekton-triggers-sa`, a `RoleBinding` to the standard `tekton-triggers-eventlistener-roles` ClusterRole shipped with Tekton Triggers, the `EventListener cd-pipeline-listener` with a CEL interceptor (filters to push events on `refs/heads/master` and overlays `branch_name`), and an OpenShift `Route` that exposes `el-cd-pipeline-listener` so GitHub webhooks can reach it.

## AC mapping
- [x] EventListener / TriggerBinding / TriggerTemplate created
- [x] All trigger files in `.tekton/` folder
- [x] TriggerTemplate produces a `PipelineRun` referencing the existing `cd-pipeline`
- [x] TriggerBinding extracts repository (`body.repository.clone_url`) and branch (`extensions.branch_name`) from the GitHub webhook payload
- [x] EventListener exposes a Route (`route.openshift.io/v1`) so the GitHub webhook URL is reachable

## Verification (locally)
All three files parse cleanly with `yaml.safe_load_all` (6 docs total) and validate with `kubectl apply --dry-run=client` for the non-CRD resources. CRD-backed resources (TriggerBinding, TriggerTemplate, EventListener, Route) require Tekton Triggers + OpenShift Routes installed on the target cluster — local K3D does not have those, so end-to-end webhook verification belongs on the OpenShift class cluster.

## To wire up GitHub webhook (post-merge, on the cluster)
```bash
kubectl apply -f .tekton/trigger-binding.yaml
kubectl apply -f .tekton/trigger-template.yaml
kubectl apply -f .tekton/event-listener.yaml
# Get the public URL:
oc get route cd-pipeline-listener -o jsonpath="{.spec.host}"
# Add the URL as a GitHub webhook (Settings → Webhooks → Add webhook), content-type application/json, event: push.
```

## Test plan
- [ ] `kubectl apply -f .tekton/{trigger-binding,trigger-template,event-listener}.yaml` succeeds on the OpenShift cluster
- [ ] `oc get el cd-pipeline-listener` shows Ready=True
- [ ] `oc get route cd-pipeline-listener` shows an active host
- [ ] Pushing to master triggers a new `cd-pipeline-run-*` PipelineRun in the cluster
- [ ] CI on this PR (lint, pytest, codecov) passes — no `service/` code changed