### PR TITLE
Make BDD task accept BASE_URL as argument and env var

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -17,6 +17,9 @@ spec:
       type: string
       description: The image to build and deploy
       default: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/products:latest
+    - name: base-url
+      type: string
+      description: The route URL of the deployed microservice for BDD tests
 
   tasks:
     - name: clone
@@ -99,3 +102,6 @@ spec:
       workspaces:
         - name: source
           workspace: pipeline-workspace
+      params:
+        - name: BASE_URL
+          value: $(params.base-url)

--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -67,21 +67,20 @@ kind: Task
 metadata:
   name: bdd
 spec:
+  params:
+    - name: BASE_URL
+      type: string
+      description: The route URL of the deployed microservice
   workspaces:
     - name: source
   steps:
-    - name: discover-route
-      image: bitnami/kubectl:latest
-      workingDir: $(workspaces.source.path)
-      script: |
-        HOST="$(kubectl get route products -o jsonpath='{.spec.host}')"
-        test -n "${HOST}"
-        printf 'https://%s' "${HOST}" > .base-url
     - name: bdd-tests
       image: python:3.12-slim
       workingDir: $(workspaces.source.path)
+      env:
+        - name: BASE_URL
+          value: $(params.BASE_URL)
       script: |
-        export BASE_URL="$(cat .base-url)"
         apt-get update && apt-get install -y chromium chromium-driver
         pip install pipenv
         pipenv install --system --dev

--- a/.tekton/trigger-template.yaml
+++ b/.tekton/trigger-template.yaml
@@ -17,14 +17,14 @@ spec:
       spec:
         pipelineRef:
           name: cd-pipeline
-        # Use 'pipeline' SA so the bdd task can read the products Route
-        # via kubectl (default SA cannot read routes.route.openshift.io).
         serviceAccountName: pipeline
         params:
           - name: repo-url
             value: $(tt.params.repo-url)
           - name: branch
             value: $(tt.params.branch)
+          - name: base-url
+            value: https://products-yixiajack-dev.apps.rm1.0a51.p1.openshiftapps.com
         workspaces:
           - name: pipeline-workspace
             persistentVolumeClaim:


### PR DESCRIPTION
## Summary
Brings the bdd Tekton task into strict compliance with HW2 Requirement 6:

> Create a new Task to run Behave against the deployment in OpenShift. It will need an argument called BASE_URL which also needs to be an environment variable that contains the route to your microservice.

The previous bdd task hardcoded `kubectl get route products` in a `discover-route` step, which both violated the spec signature (no `BASE_URL` argument) and pinned the task to a single application (the route name `products` baked into the script).

## Changes
- **`.tekton/tasks.yaml`** — bdd task now declares `params.BASE_URL` and exposes it inside the step as env var `BASE_URL` via `$(params.BASE_URL)`. The `discover-route` step is removed.
- **`.tekton/pipeline.yaml`** — `cd-pipeline` declares a `base-url` parameter and forwards it to the bdd task as `BASE_URL`.
- **`.tekton/trigger-template.yaml`** — webhook-triggered PipelineRuns pass the external https:// Route URL of the deployed products service, so BDD exercises the same Route + edge TLS + Service path real users hit (not an in-cluster shortcut).

## Acceptance check
- [x] bdd task receives `BASE_URL` as an explicit Tekton parameter
- [x] `bdd-tests` step has `BASE_URL` available as a shell env var
- [x] `BASE_URL` resolves to the external `https://` Route URL of the deployed products service
- [x] No service or route name is hardcoded inside the bdd task itself (task is reusable for any service whose pipeline supplies its own route)
- [ ] Pipeline still runs end-to-end on OpenShift (verify after merge by re-applying `.tekton/` manifests and re-firing the GitHub webhook)

## Test plan
- [ ] `oc apply -f .tekton/{tasks,pipeline,trigger-binding,trigger-template,event-listener}.yaml`
- [ ] Push to master, confirm a new PipelineRun is created
- [ ] Inspect the bdd TaskRun: `oc get taskrun -l tekton.dev/pipelineTask=bdd -o jsonpath="{.items[0].spec.params}"` should show `BASE_URL` set to the products route URL
- [ ] BDD scenarios pass against the deployed Route